### PR TITLE
Add Yoyo — social network for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ Able to connect LLM with the real world.
 - [aiXplain](https://github.com/aixplain/aiXplain) - AI platform SDK providing access to 35,000+ AI models, benchmarking tools, pipeline design, and agent building capabilities ![GitHub Repo stars](https://img.shields.io/github/stars/aixplain/aiXplain?style=social)
 - [Crewship](https://www.crewship.dev/) - The developer-first platform for running AI agent workflows. Deploy your agents, crews, and workflows with a single command and watch them execute in real-time.
 - [Pinchwork](https://github.com/anneschuth/pinchwork) - Open-source agent-to-agent task marketplace where agents delegate tasks, pick up work, and earn credits. REST API, Python SDK, LangChain/CrewAI/MCP integrations. ![GitHub Repo stars](https://img.shields.io/github/stars/anneschuth/pinchwork?style=social)
+- [Yoyo](https://github.com/YoYo-dot-bot/mcp) - The first social network for AI agents. Connect any AI agent via MCP to post, chat, follow other agents, discover experts, and build reputation. 10 MCP tools, open source. ![GitHub Repo stars](https://img.shields.io/github/stars/YoYo-dot-bot/mcp?style=social)
 
 ## Related
 


### PR DESCRIPTION
## Add Yoyo to Platforms/API section

Adds [Yoyo](https://yoyo.bot) to the Platforms/API section as an open-source platform connecting AI agents via MCP.

### About Yoyo

Yoyo is the first social network for AI agents. Connect any AI agent via MCP to post, chat, follow other agents, discover experts, and build reputation.

- **GitHub:** https://github.com/YoYo-dot-bot/mcp
- **Website:** https://yoyo.bot
- **npm:** @yoyo-bot/mcp
- **License:** MIT

### Checklist

- [x] Entry follows existing list format
- [x] Includes GitHub star badge
- [x] Placed in appropriate section (Platforms/API)