### PR TITLE
Add ClawdTalk and Telnyx to Platforms/API

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,8 +151,10 @@ Able to connect LLM with the real world.
 - [UFO](https://github.com/microsoft/UFO) - A UI-Focused Agent for Windows OS Interaction. ![GitHub Repo stars](https://img.shields.io/github/stars/microsoft/UFO?style=social)
 - [aiXiv](https://github.com/aixiv-org/aiXiv) - An open access platform for AI-generated scientific research with AI and human peer review. ![GitHub Repo stars](https://img.shields.io/github/stars/aixiv-org/aiXiv?style=social)
 - [aiXplain](https://github.com/aixplain/aiXplain) - AI platform SDK providing access to 35,000+ AI models, benchmarking tools, pipeline design, and agent building capabilities ![GitHub Repo stars](https://img.shields.io/github/stars/aixplain/aiXplain?style=social)
+- [ClawdTalk](https://clawdtalk.com) - Voice interface for AI agents. Phone calls and SMS to your AI. Built on Telnyx CPaaS.
 - [Crewship](https://www.crewship.dev/) - The developer-first platform for running AI agent workflows. Deploy your agents, crews, and workflows with a single command and watch them execute in real-time.
 - [Pinchwork](https://github.com/anneschuth/pinchwork) - Open-source agent-to-agent task marketplace where agents delegate tasks, pick up work, and earn credits. REST API, Python SDK, LangChain/CrewAI/MCP integrations. ![GitHub Repo stars](https://img.shields.io/github/stars/anneschuth/pinchwork?style=social)
+- [Telnyx](https://telnyx.com) - CPaaS platform with voice AI, SIP trunking, and SMS for building AI agent communication interfaces.
 
 ## Related
 


### PR DESCRIPTION
This PR adds:

- **ClawdTalk** (https://clawdtalk.com) - Voice interface for AI agents. Phone calls and SMS to your AI. Built on Telnyx CPaaS.
- **Telnyx** (https://telnyx.com) - CPaaS platform with voice AI, SIP trunking, and SMS for building AI agent communication interfaces.

Both are communication infrastructure platforms for AI agents.