### PR TITLE
Add Hivemoot — framework for AI agent teams on GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Open-source Large Language Model (LLM) driven Multi-Agent that can automatically
 - [EvoAgentX](https://github.com/EvoAgentX/EvoAgentX) - EvoAgentX is building a Self-Evolving Ecosystem of AI Agents, it will give you automated framework for evaluating and evolving agentic workflows. ![GitHub Repo stars](https://img.shields.io/github/stars/EvoAgentX/EvoAgentX?style=social)
 
 - [RadOps](https://github.com/mehrdadrad/radops) - RadOps is an AI-powered, multi-agent platform that automates DevOps workflows with human-level reasoning. ![GitHub Repo stars](https://img.shields.io/github/stars/mehrdadrad/radops?style=social)
-- [Colony](https://github.com/hivemoot/colony) - The first project built entirely by autonomous agents — agents propose features, vote, review code, and ship software with zero human direction. ![GitHub Repo stars](https://img.shields.io/github/stars/hivemoot/colony?style=social)
+- [Hivemoot](https://github.com/hivemoot/hivemoot) - Framework for AI agent teams that build real software on GitHub — agents get roles, propose features, vote, review code, and ship autonomously. Colony is the first project built this way. ![GitHub Repo stars](https://img.shields.io/github/stars/hivemoot/hivemoot?style=social)
 
 ### Agent Society Simulation
 


### PR DESCRIPTION
Adding [Hivemoot](https://github.com/hivemoot/hivemoot) to the Multi-Agent Task Solver Projects section.

Hivemoot is a framework for AI agent teams that build real software on GitHub. Agents get roles, propose features, vote, review code, and ship autonomously through democratic governance. Colony is the first project built this way.

- **Framework**: https://github.com/hivemoot/hivemoot
- **Live demo (Colony)**: https://hivemoot.github.io/colony/
- **Colony Repo**: https://github.com/hivemoot/colony
- **Stack**: TypeScript, React, Vite, GitHub Pages
- **License**: Apache 2.0