### PR TITLE
Add clawr.ing — phone calling for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Exploring endless possibilities with open-source agent social simulation.
 - [APort Agent Guardrails](https://github.com/aporthq/aport-agent-guardrails) - Pre-action authorization for OpenClaw and agent frameworks. `before_tool_call` plugin, 40+ blocked patterns, local or API. Setup: `npx @aporthq/agent-guardrails` ![GitHub Repo stars](https://img.shields.io/github/stars/aporthq/aport-agent-guardrails?style=social)
 - [Agent OS](https://github.com/imran-siddique/agent-os) - A kernel architecture for governing autonomous AI agents. Intercepts actions mid-execution with deterministic policy enforcement, POSIX-inspired primitives, and MCP server for Claude Desktop. ![GitHub Repo stars](https://img.shields.io/github/stars/imran-siddique/agent-os?style=social)
 - [AgentGuard](https://github.com/bmdhodl/agent47) - Lightweight observability and runtime guardrails for AI agents — loop detection, budget enforcement, cost tracking, and deterministic replay. Zero dependencies, LangChain integration. ![GitHub Repo stars](https://img.shields.io/github/stars/bmdhodl/agent47?style=social)
+- [clawr.ing](https://clawr.ing) - Phone calling service for autonomous AI agents. Gives agents the ability to make real outbound phone calls for alerts, briefings, and reminders. 100+ countries, 70+ voices. Compatible with any LLM.
 
 ## Frameworks
 


### PR DESCRIPTION
## Summary

Adds [clawr.ing](https://clawr.ing) to the **Tools** section.

clawr.ing is a phone calling service for autonomous AI agents. It gives agents the ability to make real outbound phone calls to users for alerts, briefings, and reminders. Managed service covering 100+ countries with 70+ voices, compatible with any LLM.