### PR TITLE
Add OpenPaw to Autonomous Agent Task Solver Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Open-source Large Language Model (LLM) driven autonomous agent that can automati
 - [OpenLens AI](https://github.com/jarrycyx/openlens-ai) - Fully Autonomous Research Agent for Health / Medicine ![GitHub Repo stars](https://img.shields.io/github/stars/jarrycyx/openlens-ai?style=social)
 - [DeepAnalyze](https://github.com/ruc-datalab/DeepAnalyze) - Agentic LLM that autonomously completes the full data science pipeline from preparation to analyst-grade reports. ![GitHub Repo stars](https://img.shields.io/github/stars/ruc-datalab/DeepAnalyze?style=social)
 - [KodeAgent](https://github.com/barun-saha/kodeagent) - The Minimal Agent Engine, enabling seamless integration with your platform. KodeAgent offers tool-calling (ReAct) and sanboxed code-executing (CodeAct) agents, supported by planning and observation. ![GitHub Repo stars](https://img.shields.io/github/stars/barun-saha/kodeagent?style=social)
+- [OpenPaw](https://github.com/daxaur/openpaw) - CLI tool (`npx pawmode`) that turns Claude Code into a personal assistant with 38 skills — email, calendar, Spotify, smart home, Slack, GitHub, Telegram, Discord, and more. No daemon, no cloud. ![GitHub Repo stars](https://img.shields.io/github/stars/daxaur/openpaw?style=social)
 
 ### Multi-Agent Task Solver Projects
 


### PR DESCRIPTION
Adding [OpenPaw](https://github.com/daxaur/openpaw) to the Autonomous Agent Task Solver section.

OpenPaw is a CLI tool (`npx pawmode`) that turns Claude Code into a personal assistant with 38 skills -- email, calendar, Spotify, smart home, Slack, GitHub, Telegram, Discord, and more. No daemon, no cloud, MIT licensed.

- Repo: https://github.com/daxaur/openpaw
- npm: https://www.npmjs.com/package/pawmode