### PR TITLE
Add Agent Gateway to Platforms/API section

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ Able to connect LLM with the real world.
 ![](./images/system_design.png)
 
 - [Agentfield](https://github.com/Agent-Field/agentfield) - An open source Kubernetes-style control plane for deploying AI agents as distributed microservices, with built-in service discovery, durable workflows, and observability. ![GitHub Repo stars](https://img.shields.io/github/stars/Agent-Field/agentfield?style=social)
+- [Agent Gateway](https://github.com/OzorOwn/agent-gateway) - Unified API gateway providing 39 production-ready services for AI agents under one Bearer token — wallets, code execution, scheduling, memory, DeFi, LLM routing, and more. ![GitHub Repo stars](https://img.shields.io/github/stars/OzorOwn/agent-gateway?style=social)
 - [OpenAgents](https://github.com/xlang-ai/OpenAgents) - An Open Platform for Language Agents in the Wild ![GitHub Repo stars](https://img.shields.io/github/stars/xlang-ai/OpenAgents?style=social)
 - [OpenAGI](https://github.com/agiresearch/OpenAGI) - "May the Force be with LLM and Domain Experts." ![GitHub Repo stars](https://img.shields.io/github/stars/agiresearch/OpenAGI?style=social)
 - [RestGPT](https://github.com/Yifan-Song793/RestGPT) - An LLM-based autonomous agent controlling real-world applications via RESTful APIs ![GitHub Repo stars](https://img.shields.io/github/stars/Yifan-Song793/RestGPT?style=social)


### PR DESCRIPTION
Added [Agent Gateway](https://github.com/OzorOwn/agent-gateway) to the Platforms/API section.

Agent Gateway is a unified API gateway providing 39 production-ready services for AI agents under one Bearer token — wallets, code execution, scheduling, memory, DeFi, LLM routing, and more.

**Highlights:**
- One API key → 39 services across 8 categories
- `agent.json` + `llms.txt` for LLM-native service discovery
- Zero-friction: `POST /api/keys/create` → 200 free credits
- On-chain payments: USDC on Base

**Links:**
- [Landing Page](https://agent-gateway-kappa.vercel.app)
- [Getting Started Guide](https://api-catalog-three.vercel.app/guides/getting-started)
- [GitHub](https://github.com/OzorOwn/agent-gateway)