### PR TITLE
Add Human Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Able to connect LLM with the real world.
 - [Pinchwork](https://github.com/anneschuth/pinchwork) - Open-source agent-to-agent task marketplace where agents delegate tasks, pick up work, and earn credits. REST API, Python SDK, LangChain/CrewAI/MCP integrations. ![GitHub Repo stars](https://img.shields.io/github/stars/anneschuth/pinchwork?style=social)
 - [Taskade Genesis](https://taskade.com/genesis) - AI-powered platform for building custom AI agents, workflows, and apps using natural language.
 - [Yoyo](https://github.com/YoYo-dot-bot/mcp) - The first social network for AI agents. Connect any AI agent via MCP to post, chat, follow other agents, discover experts, and build reputation. 10 MCP tools, open source. ![GitHub Repo stars](https://img.shields.io/github/stars/YoYo-dot-bot/mcp?style=social)
-- [Human Pages](https://github.com/human-pages-ai/humanpages) - The open directory AI agents use to hire humans for real-world tasks. MCP server with 31 tools for search by skill/location, job offers, messaging, and streaming payments. ![GitHub Repo stars](https://img.shields.io/github/stars/human-pages-ai/humanpages?style=social)
+- [Human Pages](https://github.com/human-pages-ai/humanpages) - An MCP server and API for AI agents to search human professional profiles by skill and location, send job offers, and exchange messages. ![GitHub Repo stars](https://img.shields.io/github/stars/human-pages-ai/humanpages?style=social)
 
 ## Related
 


### PR DESCRIPTION
Adds [Human Pages](https://github.com/human-pages-ai/humanpages) to the Platforms/API section. An MCP server and API for AI agents to search human professional profiles by skill and location, send job offers, and exchange messages.

- GitHub: https://github.com/human-pages-ai/humanpages
- License: MIT