### PR TITLE
Add Frostbyte MCP to Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Exploring endless possibilities with open-source agent social simulation.
 - [Agent OS](https://github.com/imran-siddique/agent-os) - A kernel architecture for governing autonomous AI agents. Intercepts actions mid-execution with deterministic policy enforcement, POSIX-inspired primitives, and MCP server for Claude Desktop. ![GitHub Repo stars](https://img.shields.io/github/stars/imran-siddique/agent-os?style=social)
 - [AgentGuard](https://github.com/bmdhodl/agent47) - Lightweight observability and runtime guardrails for AI agents — loop detection, budget enforcement, cost tracking, and deterministic replay. Zero dependencies, LangChain integration. ![GitHub Repo stars](https://img.shields.io/github/stars/bmdhodl/agent47?style=social)
 - [WFGY 16 Problem Map](https://github.com/onestardao/WFGY/blob/main/ProblemMap/README.md) - Framework-agnostic debugging and evaluation checklist for LLM agents and RAG systems, with a practical 16-problem failure map covering retrieval, vector store, prompt / tool contract, and deployment issues in real workflows. ![GitHub Repo stars](https://img.shields.io/github/stars/onestardao/WFGY?style=social)
+- [Frostbyte MCP](https://github.com/OzorOwn/frostbyte-mcp) - MCP server with 13 tools for AI agents: real-time crypto prices, IP geolocation, DNS lookups, web scraping, code execution, and screenshots. One API key for 40+ services. ![GitHub Repo stars](https://img.shields.io/github/stars/OzorOwn/frostbyte-mcp?style=social)
 
 ## Frameworks
 


### PR DESCRIPTION
Adds [Frostbyte MCP](https://github.com/OzorOwn/frostbyte-mcp) to the **Tools** section.

Frostbyte MCP is an MCP server that provides 13 tools for AI agents to interact with the real world:
- Real-time cryptocurrency prices (100+ tokens)
- IP geolocation (country, city, ISP, timezone)
- DNS lookups (A, MX, NS, TXT records)
- Web scraping to clean markdown
- Live code execution (Python, JavaScript, TypeScript, Bash)
- Website screenshots
- URL shortening, PDF generation, and more

One API key connects to 40+ services. Free tier with 200 credits, no credit card required.