### PR TITLE
Add WritBase — MCP-native task management for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Exploring endless possibilities with open-source agent social simulation.
 - [Agent OS](https://github.com/microsoft/agent-governance-toolkit) - A kernel architecture for governing autonomous AI agents. Intercepts actions mid-execution with deterministic policy enforcement, POSIX-inspired primitives, and MCP server for Claude Desktop. ![GitHub Repo stars](https://img.shields.io/github/stars/microsoft/agent-governance-toolkit?style=social)
 - [AgentGuard](https://github.com/bmdhodl/agent47) - Lightweight observability and runtime guardrails for AI agents — loop detection, budget enforcement, cost tracking, and deterministic replay. Zero dependencies, LangChain integration. ![GitHub Repo stars](https://img.shields.io/github/stars/bmdhodl/agent47?style=social)
 - [WFGY 16 Problem Map](https://github.com/onestardao/WFGY/blob/main/ProblemMap/README.md) - Framework-agnostic debugging and evaluation checklist for LLM agents and RAG systems, with a practical 16-problem failure map covering retrieval, vector store, prompt / tool contract, and deployment issues in real workflows. ![GitHub Repo stars](https://img.shields.io/github/stars/onestardao/WFGY?style=social)
+- [WritBase](https://github.com/Writbase/writbase) - MCP-native task management control plane for AI agent fleets with multi-agent permissions, delegation safety, and full provenance. ![GitHub Repo stars](https://img.shields.io/github/stars/Writbase/writbase?style=social)
 
 ## Frameworks
 


### PR DESCRIPTION
Adds [WritBase](https://github.com/Writbase/writbase) to the Tools section.

WritBase is an MCP-native task management control plane for AI agent fleets. It provides multi-agent permissions, inter-agent delegation safety, and full provenance tracking. Built on Supabase (Postgres).

- Open source (Apache 2.0)
- MCP-first design with 11 tools
- Multi-agent permission system

🤖 Generated with [Claude Code](https://claude.com/claude-code)