### PR TITLE
Add TITAN to Frameworks section

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ Quickly build and customize agents.
 - [pydantic-collab](https://github.com/boazkatzir/pydantic-collab) - A multi-agent framework powered by Pydantic-AI, enabling collaboration via handoffs and consultations. Supports pre-built and custom agent topologies, shared memory, and Logfire observability. ![GitHub Repo stars](https://img.shields.io/github/stars/boazkatzir/pydantic-collab?style=social)
 - [alive](https://github.com/TheAuroraAI/alive) - Minimal autonomous AI agent framework in a single Python file. Production-hardened through 80+ sessions of real autonomous operation with persistent memory, adaptive wake intervals, circuit breakers, and graceful degradation. ![GitHub Repo stars](https://img.shields.io/github/stars/TheAuroraAI/alive?style=social)
 - [OpenAgents](https://github.com/openagents-org/openagents) - Open-source platform for building AI agent networks with multi-protocol support (WebSocket, gRPC, HTTP, MCP, A2A) and multi-agent orchestration. ![GitHub Repo stars](https://img.shields.io/github/stars/openagents-org/openagents?style=social)
+- [TITAN](https://github.com/Djtony707/TITAN) - Open-source autonomous AI agent framework with 149 tools, 34 LLM providers, P2P mesh networking, WebRTC voice chat, and React dashboard. TypeScript, self-hosted, MIT licensed. ![GitHub Repo stars](https://img.shields.io/github/stars/Djtony707/TITAN?style=social)
 
 
 ## Benchmark/Evaluator


### PR DESCRIPTION
## Summary

Adds [TITAN](https://github.com/Djtony707/TITAN) to the Frameworks section.

TITAN is an open-source autonomous AI agent framework built in TypeScript with:
- 149 tools and 34 LLM providers (4 native + 30 OpenAI-compatible)
- P2P mesh networking for distributed agent setups
- WebRTC voice chat via LiveKit
- React dashboard (Mission Control)
- Sandboxed code execution
- RAG with FTS5 + embeddings
- MCP Server mode
- 3,879 tests
- MIT licensed, self-hosted
- Available on npm as [`titan-agent`](https://www.npmjs.com/package/titan-agent)

GitHub: https://github.com/Djtony707/TITAN