### PR TITLE
Add ORCH — CLI orchestrator for AI agent teams

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ Quickly build and customize agents.
 - [pydantic-collab](https://github.com/boazkatzir/pydantic-collab) - A multi-agent framework powered by Pydantic-AI, enabling collaboration via handoffs and consultations. Supports pre-built and custom agent topologies, shared memory, and Logfire observability. ![GitHub Repo stars](https://img.shields.io/github/stars/boazkatzir/pydantic-collab?style=social)
 - [alive](https://github.com/TheAuroraAI/alive) - Minimal autonomous AI agent framework in a single Python file. Production-hardened through 80+ sessions of real autonomous operation with persistent memory, adaptive wake intervals, circuit breakers, and graceful degradation. ![GitHub Repo stars](https://img.shields.io/github/stars/TheAuroraAI/alive?style=social)
 - [OpenAgents](https://github.com/openagents-org/openagents) - Open-source platform for building AI agent networks with multi-protocol support (WebSocket, gRPC, HTTP, MCP, A2A) and multi-agent orchestration. ![GitHub Repo stars](https://img.shields.io/github/stars/openagents-org/openagents?style=social)
+- [ORCH](https://github.com/oxgeneral/ORCH) - CLI runtime for orchestrating AI agent teams. Coordinates Claude Code, Codex, Cursor, and OpenCode as a typed task queue with state machine (todo→review→done), auto-retry, inter-agent messaging, shared context store, and TUI dashboard. MIT, TypeScript. ![GitHub Repo stars](https://img.shields.io/github/stars/oxgeneral/ORCH?style=social)
 
 
 ## Benchmark/Evaluator


### PR DESCRIPTION
## What is ORCH?

[ORCH](https://github.com/oxgeneral/ORCH) is a CLI runtime for orchestrating AI agent teams. It coordinates Claude Code, Codex, Cursor, and OpenCode as a typed task queue with:

- **State machine**: tasks flow `todo → in_progress → review → done` with mandatory review gate
- **Auto-retry**: failed agents automatically enter `retrying` state
- **Inter-agent messaging**: agents communicate directly via `orch msg send`
- **Shared context store**: agents share key-value context across sessions
- **TUI dashboard**: Ink/React terminal UI for real-time monitoring
- **Programmatic API**: full engine exported via `@oxgeneral/orch` npm package

## Why Frameworks section?

Fits alongside CrewAI, AutoGen, Agent Squad — all orchestration-focused frameworks. ORCH differentiates as CLI-first with state machine lifecycle management (not just parallel task launching).

## Links

- GitHub: https://github.com/oxgeneral/ORCH
- npm: https://www.npmjs.com/package/@oxgeneral/orch
- License: MIT
- Language: TypeScript (strict)