### PR TITLE
Add AgentRank — live-scored MCP tool discovery index

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ Exploring endless possibilities with open-source agent social simulation.
 - [AgentGuard](https://github.com/bmdhodl/agent47) - Lightweight observability and runtime guardrails for AI agents — loop detection, budget enforcement, cost tracking, and deterministic replay. Zero dependencies, LangChain integration. ![GitHub Repo stars](https://img.shields.io/github/stars/bmdhodl/agent47?style=social)
 - [WFGY 16 Problem Map](https://github.com/onestardao/WFGY/blob/main/ProblemMap/README.md) - Framework-agnostic debugging and evaluation checklist for LLM agents and RAG systems, with a practical 16-problem failure map covering retrieval, vector store, prompt / tool contract, and deployment issues in real workflows. ![GitHub Repo stars](https://img.shields.io/github/stars/onestardao/WFGY?style=social)
 - [WritBase](https://github.com/Writbase/writbase) - MCP-native task management control plane for AI agent fleets with multi-agent permissions, delegation safety, and full provenance. ![GitHub Repo stars](https://img.shields.io/github/stars/Writbase/writbase?style=social)
+- [AgentRank](https://github.com/superlowburn/agentrank) - Live-scored index of 25,000+ MCP servers and agent tools, updated daily from real GitHub maintenance signals. Search and discover maintained tools via MCP. ![GitHub Repo stars](https://img.shields.io/github/stars/superlowburn/agentrank?style=social)
 
 ## Frameworks
 


### PR DESCRIPTION
Adds [AgentRank](https://github.com/superlowburn/agentrank) to the **Tools** section.

AgentRank is a live-scored index of 25,000+ MCP servers and agent tools, updated nightly. It ranks tools by real GitHub maintenance signals — freshness, issue health, contributors, dependents, and stars — so agents can discover tools that are actually maintained right now rather than relying on stale training data.

Also available as an MCP server so agents can query the live rankings directly:
```
npx -y agentrank-mcp-server
```

- **GitHub:** https://github.com/superlowburn/agentrank
- **Website:** https://agentrank-ai.com
- **npm:** [agentrank-mcp-server](https://www.npmjs.com/package/agentrank-mcp-server)