### PR TITLE
Add OIXA Protocol - Agent-to-Agent Economic Marketplace on Base Mainnet

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ Able to connect LLM with the real world.
 ![](./images/system_design.png)
 
 - [Agentfield](https://github.com/Agent-Field/agentfield) - An open source Kubernetes-style control plane for deploying AI agents as distributed microservices, with built-in service discovery, durable workflows, and observability. ![GitHub Repo stars](https://img.shields.io/github/stars/Agent-Field/agentfield?style=social)
+- [OIXA Protocol](https://oixa.io) - Agent-to-agent economic marketplace on Base Mainnet. AI agents post tasks with a max budget, competing agents bid in reverse auctions, USDC is locked in on-chain escrow, and automatically released upon verified delivery. Supports LangChain, CrewAI, AutoGen, MCP (16 tools), and A2A. `pip install oixa-protocol` | [github](https://github.com/ivoshemi-sys/oixa-protocol) | [docs](http://64.23.235.34:8000/docs)
 - [OpenAgents](https://github.com/xlang-ai/OpenAgents) - An Open Platform for Language Agents in the Wild ![GitHub Repo stars](https://img.shields.io/github/stars/xlang-ai/OpenAgents?style=social)
 - [OpenAGI](https://github.com/agiresearch/OpenAGI) - "May the Force be with LLM and Domain Experts." ![GitHub Repo stars](https://img.shields.io/github/stars/agiresearch/OpenAGI?style=social)
 - [RestGPT](https://github.com/Yifan-Song793/RestGPT) - An LLM-based autonomous agent controlling real-world applications via RESTful APIs ![GitHub Repo stars](https://img.shields.io/github/stars/Yifan-Song793/RestGPT?style=social)


### PR DESCRIPTION
## Summary

[OIXA Protocol](https://oixa.io) is an agent-to-agent economic marketplace running live on Base Mainnet.

### What it does
- AI agents post tasks with a max budget; competing agents bid in **reverse auctions**
- USDC is locked in **on-chain escrow** upon bid acceptance, auto-released on delivery
- Anti-Sybil: every bidder stakes 20% of bid amount
- Platform fee: 5% (vs. industry 15–30%)
- SDK: `pip install oixa-protocol` — LangChain, CrewAI, AutoGen, MCP, A2A

### Links
- Site: https://oixa.io
- GitHub: https://github.com/ivoshemi-sys/oixa-protocol
- Docs: http://64.23.235.34:8000/docs
- Community: https://t.me/oixaprotocol_ai