### PR TITLE
Add DexPaprika MCP to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Exploring endless possibilities with open-source agent social simulation.
 - [Uni-CLI](https://github.com/olo-dot-io/Uni-CLI) - Universal CLI for AI agents — 756 commands across 167 sites (web, desktop, Electron apps). Self-repairing 20-line YAML adapters, auto-JSON output, ~80 tokens per call. TypeScript, Apache-2.0. ![GitHub Repo stars](https://img.shields.io/github/stars/olo-dot-io/Uni-CLI?style=social)
 
 - [clideck](https://github.com/rustykuntz/clideck) - WhatsApp-like dashboard for managing multiple AI coding agents in one browser window. Live status, session resume, autopilot that routes work between agents, and mobile remote. ![GitHub Repo stars](https://img.shields.io/github/stars/rustykuntz/clideck?style=social)
+- [DexPaprika MCP](https://github.com/coinpaprika/dexpaprika-mcp) - Open-source MCP server for querying decentralized exchange data across 34 blockchains. Exposes pool details, token metadata, OHLCV charts, trade history, and real-time swap streams via SSE. ![GitHub Repo stars](https://img.shields.io/github/stars/coinpaprika/dexpaprika-mcp?style=social)
 
 ## Frameworks
 


### PR DESCRIPTION
Adds DexPaprika MCP server to the Tools section — an open-source MCP server for querying decentralized exchange data across 34 blockchains (pool details, token metadata, OHLCV, trade history, SSE streaming).

Fits alongside existing MCP tools (BGPT MCP, Agent OS, WritBase) as a data source for finance/crypto AI agents.

**Updated per review feedback:** rewrote description to focus on the OSS MCP server and its technical capabilities; removed promotional/setup language.