### PR TITLE
Add SidClaw to Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Exploring endless possibilities with open-source agent social simulation.
 - [AgentGuard](https://github.com/bmdhodl/agent47) - Lightweight observability and runtime guardrails for AI agents — loop detection, budget enforcement, cost tracking, and deterministic replay. Zero dependencies, LangChain integration. ![GitHub Repo stars](https://img.shields.io/github/stars/bmdhodl/agent47?style=social)
 - [WFGY 16 Problem Map](https://github.com/onestardao/WFGY/blob/main/ProblemMap/README.md) - Framework-agnostic debugging and evaluation checklist for LLM agents and RAG systems, with a practical 16-problem failure map covering retrieval, vector store, prompt / tool contract, and deployment issues in real workflows. ![GitHub Repo stars](https://img.shields.io/github/stars/onestardao/WFGY?style=social)
 - [WritBase](https://github.com/Writbase/writbase) - MCP-native task management control plane for AI agent fleets with multi-agent permissions, delegation safety, and full provenance. ![GitHub Repo stars](https://img.shields.io/github/stars/Writbase/writbase?style=social)
+- [SidClaw](https://github.com/sidclawhq/platform) - Open-source governance proxy for AI agents. Wraps tool calls with policy evaluation, human approval workflows, and hash-chain audit trails. 18+ framework integrations. Apache 2.0. ![GitHub Repo stars](https://img.shields.io/github/stars/sidclawhq/platform?style=social)
 
 ## Frameworks
 


### PR DESCRIPTION
Adds [SidClaw](https://github.com/sidclawhq/platform) to the Tools section.

SidClaw is an open-source governance proxy for AI agents. It wraps tool calls with policy evaluation, human approval workflows, and hash-chain audit trails. 18+ framework integrations. Apache 2.0 licensed.

- GitHub: https://github.com/sidclawhq/platform
- Website: https://sidclaw.com
- Docs: https://docs.sidclaw.com

Entry follows the existing format with GitHub star badge.