### PR TITLE
Add Asqav to Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Exploring endless possibilities with open-source agent social simulation.
 - [AgentGuard](https://github.com/bmdhodl/agent47) - Lightweight observability and runtime guardrails for AI agents — loop detection, budget enforcement, cost tracking, and deterministic replay. Zero dependencies, LangChain integration. ![GitHub Repo stars](https://img.shields.io/github/stars/bmdhodl/agent47?style=social)
 - [WFGY 16 Problem Map](https://github.com/onestardao/WFGY/blob/main/ProblemMap/README.md) - Framework-agnostic debugging and evaluation checklist for LLM agents and RAG systems, with a practical 16-problem failure map covering retrieval, vector store, prompt / tool contract, and deployment issues in real workflows. ![GitHub Repo stars](https://img.shields.io/github/stars/onestardao/WFGY?style=social)
 - [WritBase](https://github.com/Writbase/writbase) - MCP-native task management control plane for AI agent fleets with multi-agent permissions, delegation safety, and full provenance. ![GitHub Repo stars](https://img.shields.io/github/stars/Writbase/writbase?style=social)
+- [Asqav](https://github.com/jagmarques/asqav-sdk) - Open-source SDK for AI agent governance with tamper-evident audit trails, tool scanning, and enforcement policies. ![GitHub Repo stars](https://img.shields.io/github/stars/jagmarques/asqav-sdk?style=social)
 
 ## Frameworks
 


### PR DESCRIPTION
Adds Asqav to the Tools section.

[Asqav](https://github.com/jagmarques/asqav-sdk) is an open-source SDK for AI agent governance with tamper-evident audit trails, tool scanning, and enforcement policies.

- Open source (MIT license)
- Published on PyPI
- Matches existing entry format with star badge