### PR TITLE
Add Uni-CLI to Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Exploring endless possibilities with open-source agent social simulation.
 - [AgentGuard](https://github.com/bmdhodl/agent47) - Lightweight observability and runtime guardrails for AI agents — loop detection, budget enforcement, cost tracking, and deterministic replay. Zero dependencies, LangChain integration. ![GitHub Repo stars](https://img.shields.io/github/stars/bmdhodl/agent47?style=social)
 - [WFGY 16 Problem Map](https://github.com/onestardao/WFGY/blob/main/ProblemMap/README.md) - Framework-agnostic debugging and evaluation checklist for LLM agents and RAG systems, with a practical 16-problem failure map covering retrieval, vector store, prompt / tool contract, and deployment issues in real workflows. ![GitHub Repo stars](https://img.shields.io/github/stars/onestardao/WFGY?style=social)
 - [WritBase](https://github.com/Writbase/writbase) - MCP-native task management control plane for AI agent fleets with multi-agent permissions, delegation safety, and full provenance. ![GitHub Repo stars](https://img.shields.io/github/stars/Writbase/writbase?style=social)
+- [Uni-CLI](https://github.com/olo-dot-io/Uni-CLI) - Universal CLI for AI agents — 756 commands across 167 sites (web, desktop, Electron apps). Self-repairing 20-line YAML adapters, auto-JSON output, ~80 tokens per call. TypeScript, Apache-2.0. ![GitHub Repo stars](https://img.shields.io/github/stars/olo-dot-io/Uni-CLI?style=social)
 
 ## Frameworks
 


### PR DESCRIPTION
## Add Uni-CLI

[Uni-CLI](https://github.com/olo-dot-io/Uni-CLI) is a universal CLI for AI agents — 756 commands across 167 sites (web, desktop, Electron apps). Self-repairing 20-line YAML adapters, auto-JSON output, ~80 tokens per call. TypeScript, Apache-2.0.

**Why it fits this list:** Uni-CLI is an agent tool/infrastructure — it gives LLM-driven agents a CLI to interact with any internet application or local software. When a command fails, agents can read the structured error, edit the YAML adapter, and self-repair.

- npm: `@zenalexa/unicli`
- GitHub: https://github.com/olo-dot-io/Uni-CLI

Added to the **Tools** section, matching existing entry format.