### PR TITLE
Add x-twitter-scraper to Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Exploring endless possibilities with open-source agent social simulation.
 - [Uni-CLI](https://github.com/olo-dot-io/Uni-CLI) - Universal CLI for AI agents — 756 commands across 167 sites (web, desktop, Electron apps). Self-repairing 20-line YAML adapters, auto-JSON output, ~80 tokens per call. TypeScript, Apache-2.0. ![GitHub Repo stars](https://img.shields.io/github/stars/olo-dot-io/Uni-CLI?style=social)
 
 - [clideck](https://github.com/rustykuntz/clideck) - WhatsApp-like dashboard for managing multiple AI coding agents in one browser window. Live status, session resume, autopilot that routes work between agents, and mobile remote. ![GitHub Repo stars](https://img.shields.io/github/stars/rustykuntz/clideck?style=social)
+- [x-twitter-scraper](https://github.com/Xquik-dev/x-twitter-scraper) - X (Twitter) data platform for AI agents — 122 REST API endpoints, 2 MCP tools, 23 extraction types. Search tweets, look up users, post, monitor accounts, run giveaways. API key auth, $0.00015/read. ![GitHub Repo stars](https://img.shields.io/github/stars/Xquik-dev/x-twitter-scraper?style=social)
 
 ## Frameworks
 


### PR DESCRIPTION
Adds [x-twitter-scraper](https://github.com/Xquik-dev/x-twitter-scraper) to the Tools section.

X (Twitter) data platform for AI agents — 122 REST API endpoints, 2 MCP tools, 23 extraction types. Search tweets, look up users, post, monitor accounts, run giveaways. API key auth, $0.00015/read.