### PR TITLE
Add ClawBench to benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ Benchmarks to evaluate LLM-as-Agent across a variety of environments.
 - [LLM-Agent-Benchmark-List](https://github.com/zhangxjohn/LLM-Agent-Benchmark-List) - A benchmark list for evaluation of large language models.
 - [agbenchmark](https://pypi.org/project/agbenchmark/) - by AutoGPT
 - [open-operator-evals](https://github.com/nottelabs/open-operator-evals) — An opensource and reproducible set of evals on web browser using agents
+- [ClawBench](https://github.com/reacher-z/ClawBench) - Browser-agent benchmark of 153 everyday tasks on 144 live production websites across 15 categories; a submission-interception layer blocks the final write request for safe evaluation on real sites. ![GitHub Repo stars](https://img.shields.io/github/stars/reacher-z/ClawBench?style=social)
 
 
 ## Platforms/API


### PR DESCRIPTION
Hi maintainers, opening a PR to add ClawBench, a browser-agent benchmark released on arXiv 2026-04-09.

What it is: 153 everyday web tasks on 144 live production websites across 15 life categories. Unlike WebArena-style sandbox benchmarks, it evaluates agents on real production sites via a submission-interception layer that captures only the final write request.

Headline result: 7 frontier models evaluated; the best passes 33.3%. Paper at arxiv.org/abs/2604.08523.

I believe this fits the Benchmark/Evaluator section of your list.

Thanks for maintaining the list.

Disclosure: I'm affiliated with the ClawBench project.