### PR TITLE
Add agentic-anti-patterns to Related > Paper-List Repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ Able to connect LLM with the real world.
 - [LLMAgentPapers](https://github.com/zjunlp/LLMAgentPapers) - Must-read Papers on LLM Agents.
 
 - [Awesome-Embodied-AI-Safety](https://github.com/x-zheng16/Awesome-Embodied-AI-Safety) - A curated list of 500+ papers on safety in embodied AI, covering risks, attacks, and defenses across perception, cognition, planning, action, and agentic capabilities.
+- [agentic-anti-patterns](https://github.com/jimliu741523/agentic-anti-patterns) - Curated catalog of 16 documented LLM-agent failure modes (prompt injection via tool output, runaway tool loops, MCP server trust boundary collapse, memory poisoning, exfiltration, goal drift, and others) with symptoms, root causes, mitigations, and detection methods per entry.
 
 ### Blog
 


### PR DESCRIPTION
Adding **agentic-anti-patterns** to the `### Tools` section.

**What it is.** A curated catalog of 14 documented AI agent failure modes — prompt injection via tool output, runaway tool loops, hallucinated tool calls, destructive actions, context bloat, semantic goal drift, silent regression on model swap, memory poisoning, tool-selection lock-in, confidence inflation on self-verification, exfiltration via agent-initiated fetch, agent-to-agent injection, planner/executor divergence, and silent retry masking failure. Each entry: TL;DR, symptom, example (reproduction or cited incident), root cause, 2–4 mitigations, detection.

**Why it fits Tools.** The section already contains conceptually-adjacent failure-map / debugging resources such as WFGY 16 Problem Map and observability guardrails (AgentGuard, Agentic Radar). `agentic-anti-patterns` complements these with a broader, production-focused failure catalog.

**OSS status.** MIT-licensed. No commercial backend. Self-contained markdown; no hosted service dependency. Contribution template and roadmap included.

**Format.** Followed `CONTRIBUTING.md`: single-entry PR, neutral one-line description, correct section, GitHub stars badge included. Inserted at the end of the Tools section (chronological ordering convention).