### PR TITLE
Add agent-memory-lab to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ Exploring endless possibilities with open-source agent social simulation.
 - [clideck](https://github.com/rustykuntz/clideck) - WhatsApp-like dashboard for managing multiple AI coding agents in one browser window. Live status, session resume, autopilot that routes work between agents, and mobile remote. ![GitHub Repo stars](https://img.shields.io/github/stars/rustykuntz/clideck?style=social)
 - [DexPaprika MCP](https://github.com/coinpaprika/dexpaprika-mcp) - Open-source MCP server for querying decentralized exchange data across 34 blockchains. Exposes pool details, token metadata, OHLCV charts, trade history, and real-time swap streams via SSE. ![GitHub Repo stars](https://img.shields.io/github/stars/coinpaprika/dexpaprika-mcp?style=social)
 - [Desktop Control](https://github.com/yaroshevych/desktopctl) - CLI tool for AI agents to control macOS apps via screen, mouse, and keyboard. GPU-accelerated, local OCR and vision, works with any AI model. ![GitHub Repo stars](https://img.shields.io/github/stars/yaroshevych/desktopctl?style=social)
+- [agent-memory-lab](https://github.com/jimliu741523/agent-memory-lab) - Five memory patterns for LLM agents (sliding window, summary compression, hierarchical summary, vector retrieval, structured episodic) with a shared add()/view() interface for drop-in swap. Stdlib-only, zero runtime deps. ![GitHub Repo stars](https://img.shields.io/github/stars/jimliu741523/agent-memory-lab?style=social)
 
 ## Frameworks
 


### PR DESCRIPTION
Adding **agent-memory-lab** to the `### Tools` section.

**What it is.** Side-by-side minimal implementations of agent memory patterns — sliding window, summary compression (with a pluggable `summarize_fn`), and hierarchical summary (cascading-fanout pyramid). Vector retrieval and structured episodic are planned. All shipped patterns share the same `add(msg)` / `view() -> list[Message]` interface, so swapping memory strategies in an agent is one line.

**Why it fits Tools.** The Tools section already contains several memory-focused entries (mem0, Agent Brain, Cortex, musecl-memory). `agent-memory-lab` complements these by providing *comparable* minimal implementations you can drop into any agent, rather than a single memory product.

**OSS status.** MIT-licensed. Zero runtime deps for the core. Stdlib-only tests (13/13). No hosted service dependency.

**Format.** Followed `CONTRIBUTING.md`: single-entry PR, neutral one-line description, correct section, GitHub stars badge included.