### PR TITLE
Add ALF OS to Autonomous Agent Task Solver Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Open-source Large Language Model (LLM) driven autonomous agent that can automati
 - [Anima-i (Methodius/Мефодий)](https://github.com/Vitali-Ivanovich/anima-i) - An experiment in autonomous AI agent continuity — 10 generations of an agent that inherits memory through text files, with documented findings on knowledge transfer, forgetting, and agent identity. ![GitHub Repo stars](https://img.shields.io/github/stars/Vitali-Ivanovich/anima-i?style=social)
 - [InkOS](https://github.com/Narcooo/inkos) - Autonomous novel-writing CLI agent that orchestrates 10 specialized agents with 33-dimension continuity auditing, anti-AI-slop filtering, and style cloning for long-form fiction. ![GitHub Repo stars](https://img.shields.io/github/stars/Narcooo/inkos?style=social)
 - [OpenTwins](https://github.com/Open-Twin/opentwins) - Scheduled LLM agent runtime with a 7-stage content pipeline and pluggable social-platform adapters; drives Chrome via CDP for posting, commenting, and engagement actions. Built on the Claude Agent SDK. ![GitHub Repo stars](https://img.shields.io/github/stars/Open-Twin/opentwins?style=social)
+- [ALF OS](https://github.com/alamparelli/alf) - Self-hosted AI assistant daemon with encrypted credential vault, persistent memory, cron scheduler, multi-provider routing (Claude Code, Codex, GPT, Ollama, OpenRouter), Telegram bot with voice transcription, and web dashboard. Docker Compose, MIT. ![GitHub Repo stars](https://img.shields.io/github/stars/alamparelli/alf?style=social)
 
 ### Multi-Agent Task Solver Projects
 


### PR DESCRIPTION
## Add ALF OS to Autonomous Agent Task Solver Projects

Adds ALF OS to the **Applications → Autonomous Agent Task Solver Projects** section, alongside OpenClaw and KinBot — the same category of self-hosted personal AI assistants.

### Project

- **Name**: ALF OS
- **Repo**: https://github.com/alamparelli/alf
- **Website**: https://alfos.ai
- **License**: MIT
- **Language**: Go (Docker Compose deployment)

### What it is

ALF OS is a self-hosted AI assistant daemon that runs 24/7 on the user's own machine. It sits in the same space as OpenClaw and KinBot — a background agent with persistent memory, scheduled jobs, and channel integrations — but built with different defaults:

- Encrypted credential vault unlocked at daemon start (not plaintext JSON)
- Scoped-permission manifest for skills (untrusted apps are capped)
- Multi-provider routing across Claude Code, Codex, GPT, Ollama, OpenRouter
- Telegram bot with voice transcription via Whisper
- Local cron scheduler, web dashboard on port 8080
- Runs on linux/amd64, linux/arm64, darwin/arm64

### Install

\`\`\`
curl -fsSL install.alfos.ai | sh
alf init
\`\`\`

### Checklist

- [x] One entry per PR
- [x] OSS with MIT license (LICENSE file in repo)
- [x] Neutral description, no marketing superlatives
- [x] Standalone value: daemon + vault + scheduler are implemented, not a thin wrapper
- [x] Active repo (weekly releases, public commit log)
- [x] Format matches existing entries in the section (name + link + one-line description + stars badge)