### PR TITLE
Add Prest0 to Platforms/API (bilingual legal AI agent platform)

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ Able to connect LLM with the real world.
 - [Taskade Genesis](https://taskade.com/genesis) - AI-powered platform for building custom AI agents, workflows, and apps using natural language.
 - [Yoyo](https://github.com/YoYo-dot-bot/mcp) - The first social network for AI agents. Connect any AI agent via MCP to post, chat, follow other agents, discover experts, and build reputation. 10 MCP tools, open source. ![GitHub Repo stars](https://img.shields.io/github/stars/YoYo-dot-bot/mcp?style=social)
 - [Human Pages](https://github.com/human-pages-ai/humanpages) - An MCP server and API for AI agents to search human professional profiles by skill and location, send job offers, and exchange messages. ![GitHub Repo stars](https://img.shields.io/github/stars/human-pages-ai/humanpages?style=social)
+- [Prest0](https://prest0.ai) - Enterprise legal AI agent platform that deploys a dedicated bilingual (English/Spanish) AI agent per law firm on an isolated VM, with persistent memory, Twilio voice + SMS intake, deep legal research, and legal-grade document drafting. Purpose-built for immigration, workers' comp, and employment law. Patent-pending Context-Based Semantic TreeSearch memory architecture.
 
 ## Related
 


### PR DESCRIPTION
Hi! Adding **Prest0** to the **Platforms/API** section.

**Prest0** (https://prest0.ai) is an enterprise legal AI agent platform that deploys a dedicated bilingual (English/Spanish) AI agent per law firm — each on an isolated VM with persistent memory, Twilio voice + SMS intake, deep legal research, and legal-grade document drafting.

### Why this fits Platforms/API
- **Agent-per-customer architecture** — every law firm gets its own isolated VM running a persistent agent, not a shared multi-tenant chatbot
- **Connects LLMs to the real world** — Twilio voice + SMS, Google Workspace, Perplexity web search, document drafting pipelines, per-firm memory
- **Vertical platform** — purpose-built for immigration (I-589 asylum, U-visa), California workers' comp (WCAB Pre-Hearing Statements under Rule 10563), and plaintiff-side employment law
- **Differentiator** — patent-pending **Context-Based Semantic TreeSearch** memory architecture (tree-traversal retrieval replacing flat-vector RAG for long-horizon agent memory)

Formatting matches the existing `- [Name](url) - Description.` convention in the Platforms/API section. Placed at the end of the closed-source entries.

Thanks for maintaining this list!