### PR TITLE
Add Hive Intelligence (crypto market infrastructure for AI agents)

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ Able to connect LLM with the real world.
 - [Taskade Genesis](https://taskade.com/genesis) - AI-powered platform for building custom AI agents, workflows, and apps using natural language.
 - [Yoyo](https://github.com/YoYo-dot-bot/mcp) - The first social network for AI agents. Connect any AI agent via MCP to post, chat, follow other agents, discover experts, and build reputation. 10 MCP tools, open source. ![GitHub Repo stars](https://img.shields.io/github/stars/YoYo-dot-bot/mcp?style=social)
 - [Human Pages](https://github.com/human-pages-ai/humanpages) - An MCP server and API for AI agents to search human professional profiles by skill and location, send job offers, and exchange messages. ![GitHub Repo stars](https://img.shields.io/github/stars/human-pages-ai/humanpages?style=social)
+- [Hive Intelligence](https://github.com/hive-intel/hive-crypto-mcp) - Institutional-grade crypto market infrastructure for AI — live prices, DeFi, wallets, and token risk through a managed MCP, REST API, or CLI. Works with Claude, Cursor, ChatGPT, Gemini, Windsurf. ![GitHub Repo stars](https://img.shields.io/github/stars/hive-intel/hive-crypto-mcp?style=social)
 
 ## Related
 


### PR DESCRIPTION
Adds [Hive Intelligence](https://github.com/hive-intel/hive-crypto-mcp) to the **Platforms/API** section.

**What it is:** institutional-grade crypto market infrastructure for AI — a managed MCP server, REST API, and CLI that connect AI agents to live crypto prices, DeFi activity, wallet positions, and token risk across every major chain. Hundreds of normalized tools across 14 category-scoped endpoints. Works with Claude Desktop, Claude Code, Cursor, ChatGPT Desktop, Windsurf, VS Code (GitHub Copilot Chat), Gemini CLI, and any MCP-compatible client.

**Why Platforms/API fits:** Hive is the data layer that "connects LLMs with the real world" (the section tagline) for crypto/on-chain use cases. Placement is at the end of the section in the standard `- [Name](url) - description + star badge` format consistent with existing entries like Yoyo, Human Pages, and Pinchwork.