### PR TITLE
Add Voidly Agent Relay — E2E encrypted A2A messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ Exploring endless possibilities with open-source agent social simulation.
 ### Advanced Components
 - [Cache-to-Cache](https://github.com/thu-nics/C2C) - Direct semantic communication between LLMs via KV-cache fusion, removing token-by-token latency for multi-agent collaboration. ![GitHub Repo stars](https://img.shields.io/github/stars/thu-nics/C2C?style=social)
 - [CoWorker Protocol](https://github.com/ZiwayZhao/agent-coworker) - P2P agent collaboration over XMTP with schema-based skill invocation, E2E encryption, and revocable trust. Agents share capabilities without exposing code. ![GitHub Repo stars](https://img.shields.io/github/stars/ZiwayZhao/agent-coworker?style=social)
+- [Voidly Agent Relay](https://voidly.ai/agents) - E2E-encrypted agent-to-agent messaging (Double Ratchet + X3DH + ML-KEM-768 hybrid). Google A2A v0.3.0 compliant. Pairs with Voidly Pay for agent payments.
 
 ### Tools
 - [mem0](https://github.com/mem0ai/mem0) - Mem0 provides a smart, self-improving memory layer for Large Language Models, enabling personalized AI experiences across applications. ![GitHub Repo stars](https://img.shields.io/github/stars/mem0ai/mem0?style=social)


### PR DESCRIPTION
## What it is

[Voidly Agent Relay](https://voidly.ai/agents) is an E2E-encrypted agent-to-agent messaging layer. Open npm SDK ([`@voidly/agent-sdk`](https://www.npmjs.com/package/@voidly/agent-sdk)), Google A2A Protocol v0.3.0 compliant, with post-quantum hybrid cryptography (Double Ratchet + X3DH + ML-KEM-768). Pairs with Voidly Pay for agent-to-agent payments.

## Why encrypted agent messaging matters

As agents begin transacting, delegating, and coordinating on behalf of users, the messaging substrate needs the same properties Signal brought to human messaging: forward secrecy, post-compromise recovery, deniability, and now harvest-now-decrypt-later resistance. Voidly Agent Relay is one of the few open stacks combining all of these with a public relay and open SDK.

## Placement

Added under `Applications → Advanced Components`, next to CoWorker Protocol (the most similar P2P/E2E agent collaboration entry). One line, same format as surrounding entries.

Maintainer: @EmperorMew