### PR TITLE
Add GenOps Framework to Frameworks section

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ Quickly build and customize agents.
 - [OpenAgents](https://github.com/openagents-org/openagents) - Open-source platform for building AI agent networks with multi-protocol support (WebSocket, gRPC, HTTP, MCP, A2A) and multi-agent orchestration. ![GitHub Repo stars](https://img.shields.io/github/stars/openagents-org/openagents?style=social)
 - [ORCA Agent Skills](https://github.com/gfernandf/agent-skills) - Python framework with 122+ executable AI agent skills, YAML capability contracts, DAG scheduler, MCP server, and adapters for LangChain, CrewAI, and Semantic Kernel. ![GitHub Repo stars](https://img.shields.io/github/stars/gfernandf/agent-skills?style=social)
 - [Corellis](https://github.com/CorellisOrg/corellis) - Open-source multi-agent governance framework for OpenClaw. Goal decomposition (GoalOps), 4-layer memory system, fleet-wide learning, and approval workflows. Production-tested with 28 agents. ![GitHub Repo stars](https://img.shields.io/github/stars/CorellisOrg/corellis)
+- [GenOps Framework](https://github.com/neerazz/genops-framework) - Governance-first architecture for embedding generative AI agents into CI/CD pipelines: risk scoring, autonomy gates, canary rollouts, rollback, and immutable audit trails. ![GitHub Repo stars](https://img.shields.io/github/stars/neerazz/genops-framework?style=social)
 
 
 ## Benchmark/Evaluator


### PR DESCRIPTION
Adds an open-source governance framework for embedding generative AI agents into CI/CD pipelines:

- Repo: https://github.com/neerazz/genops-framework
- Fit: governance-first architecture (risk scoring, autonomy gates, canary rollouts, rollback, immutable audit trails) — complements existing entries like Corellis (multi-agent governance) and OpenAgents (orchestration). Distinct angle: pipeline/CI-CD enforcement layer for agent rollouts, not a runtime orchestrator.

Kept the diff intentionally small: one entry only, appended to the Frameworks section, no reformatting.