### PR TITLE
Add KubeStellar Console to Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ Exploring endless possibilities with open-source agent social simulation.
 - [clideck](https://github.com/rustykuntz/clideck) - WhatsApp-like dashboard for managing multiple AI coding agents in one browser window. Live status, session resume, autopilot that routes work between agents, and mobile remote. ![GitHub Repo stars](https://img.shields.io/github/stars/rustykuntz/clideck?style=social)
 - [DexPaprika MCP](https://github.com/coinpaprika/dexpaprika-mcp) - Open-source MCP server for querying decentralized exchange data across 34 blockchains. Exposes pool details, token metadata, OHLCV charts, trade history, and real-time swap streams via SSE. ![GitHub Repo stars](https://img.shields.io/github/stars/coinpaprika/dexpaprika-mcp?style=social)
 - [Desktop Control](https://github.com/yaroshevych/desktopctl) - CLI tool for AI agents to control macOS apps via screen, mouse, and keyboard. GPU-accelerated, local OCR and vision, works with any AI model. ![GitHub Repo stars](https://img.shields.io/github/stars/yaroshevych/desktopctl?style=social)
+- [KubeStellar Console](https://github.com/kubestellar/console) - Multi-cluster Kubernetes dashboard with AI operations agent (kc-agent) that bridges LLMs to live clusters via MCP for AI-assisted troubleshooting, observability, and management across edge and cloud. CNCF Sandbox project. ![GitHub Repo stars](https://img.shields.io/github/stars/kubestellar/console?style=social)
 
 ## Frameworks
 


### PR DESCRIPTION
Add [KubeStellar Console](https://github.com/kubestellar/console) to the Tools section.

KubeStellar Console is a multi-cluster Kubernetes dashboard with an AI operations agent (kc-agent) that bridges LLMs to live clusters via the Model Context Protocol (MCP). It enables AI-assisted troubleshooting, observability, and management across edge and cloud clusters. CNCF Sandbox project, Apache-2.0 license.