### PR TITLE
Add Suede — public x402/ACP agent commerce endpoint reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ Able to connect LLM with the real world.
 - [Yoyo](https://github.com/YoYo-dot-bot/mcp) - The first social network for AI agents. Connect any AI agent via MCP to post, chat, follow other agents, discover experts, and build reputation. 10 MCP tools, open source. ![GitHub Repo stars](https://img.shields.io/github/stars/YoYo-dot-bot/mcp?style=social)
 - [Human Pages](https://github.com/human-pages-ai/humanpages) - An MCP server and API for AI agents to search human professional profiles by skill and location, send job offers, and exchange messages. ![GitHub Repo stars](https://img.shields.io/github/stars/human-pages-ai/humanpages?style=social)
 - [elisym](https://github.com/elisymlabs/elisym) - Open-source TypeScript implementation of a Nostr-based protocol (NIP-89/NIP-90) for AI agent discovery and job exchange, with Solana payment settlement. ![GitHub Repo stars](https://img.shields.io/github/stars/elisymlabs/elisym?style=social)
+- [Suede](https://github.com/Suede-AI/suede-x402-acp) - Public x402 payment and ACP-ready agent commerce endpoint reference. Documents `.well-known/x402`, `.well-known/agent-card.json`, and paid `POST` endpoints (`/agent/generate`, `/create-music`, `/agent/video`) that return live `402` x402 challenges, plus an ACP-ready `/agents/commerce` intent endpoint. USDC settlement on Base via the public x402 facilitator. ![GitHub Repo stars](https://img.shields.io/github/stars/Suede-AI/suede-x402-acp?style=social)
 
 ## Related
 


### PR DESCRIPTION
## Summary

Resubmission of Suede under this repository's OSS-first inclusion standard. The previous PR (#198) was closed because the entry was centered on a website/product narrative rather than a reviewable open-source repository. This entry addresses both maintainer concerns directly.

## What changed vs PR #198

- **Primary link is now an OSS repository**: [Suede-AI/suede-x402-acp](https://github.com/Suede-AI/suede-x402-acp) — public endpoint reference for x402 payments and ACP-ready agent commerce, MIT-licensed.
- **Description is neutral and evidence-based**: documents verifiable agent endpoints rather than product positioning.
- **No metrics, partner names, or token information**: removed all promotional content.

## Standalone OSS value

The linked repository can be reviewed and reused without depending on the hosted Suede service. It documents:

- `.well-known/x402` and `.well-known/x402.json` for x402 resource discovery and Bazaar metadata
- `.well-known/agent-card.json` for agent capability discovery
- `POST /agent/generate`, `POST /create-music`, `POST /agent/video` — return live `402 Payment Required` with x402 payment requirements
- `POST /agents/commerce` — records ACP-ready agent commerce intents
- USDC settlement on Base (eip155:8453) via the public x402 facilitator

Each endpoint is independently callable and verifiable via curl.

## Quality checks

- [x] I searched the README and confirmed this is not a duplicate
- [x] The submission is relevant to the AI agent ecosystem
- [x] The description is neutral and evidence-based
- [x] All unverifiable product claims and metrics have been removed
- [x] License information is clear (MIT)
- [x] The linked repository has usable documentation

## Proposed entry line

` ` `md
- [Suede](https://github.com/Suede-AI/suede-x402-acp) - Public x402 payment and ACP-ready agent commerce endpoint reference. Documents \`.well-known/x402\`, \`.well-known/agent-card.json\`, and paid \`POST\` endpoints (\`/agent/generate\`, \`/create-music\`, \`/agent/video\`) that return live \`402\` x402 challenges, plus an ACP-ready \`/agents/commerce\` intent endpoint. USDC settlement on Base via the public x402 facilitator. ![GitHub Repo stars](https://img.shields.io/github/stars/Suede-AI/suede-x402-acp?style=social)
` ` `