### PR TITLE
Add Cross-Agent Review Queue 2026 dataset to Benchmark/Evaluator

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ Benchmarks to evaluate LLM-as-Agent across a variety of environments.
 - [agbenchmark](https://pypi.org/project/agbenchmark/) - by AutoGPT
 - [open-operator-evals](https://github.com/nottelabs/open-operator-evals) — An opensource and reproducible set of evals on web browser using agents
 - [ClawBench](https://github.com/reacher-z/ClawBench) - Browser-agent benchmark of 153 everyday tasks on 144 live production websites across 15 categories; a submission-interception layer blocks the final write request for safe evaluation on real sites. ![GitHub Repo stars](https://img.shields.io/github/stars/reacher-z/ClawBench?style=social)
+- [Cross-Agent Review Queue 2026](https://huggingface.co/datasets/neogenesislab/cross-agent-review-queue-2026) - Open dataset of cross-agent collaboration review transcripts (Codex <-> Claude reviewer / architect / implementer handoffs) with structured fields for owner-goal restatement, review lens, and result code (NEW_SIGNAL / NO_NEW_SIGNAL); useful for multi-agent handoff and review-quality evaluation.
 
 
 ## Platforms/API


### PR DESCRIPTION
## What this adds

Adds [Cross-Agent Review Queue 2026](https://huggingface.co/datasets/neogenesislab/cross-agent-review-queue-2026) to the **Benchmark/Evaluator** section.

## Why it's useful

An open dataset of cross-agent collaboration review transcripts capturing real Codex <-> Claude handoffs (reviewer / architect / implementer modes). Each row includes structured fields for owner-goal restatement, scope, review lens (risk / architecture / usability / security / rollout), and outcome code (NEW_SIGNAL / NO_NEW_SIGNAL). Useful as ground-truth signal for multi-agent handoff quality and as a benchmark for review-quality evaluation — a relatively rare angle in agent eval literature, which mostly focuses on tool-use and task completion.

- License: CC-BY-4.0
- Format: Loadable via `datasets.load_dataset()`
- Fits the **Benchmark/Evaluator** section per the repo's CONTRIBUTING.md scope (real-world handoff data with maintainability signals)