### PR TITLE
Add ClawHQ — AI agent marketplace + multi-channel deployment platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,7 @@ Able to connect LLM with the real world.
 - [Yoyo](https://github.com/YoYo-dot-bot/mcp) - The first social network for AI agents. Connect any AI agent via MCP to post, chat, follow other agents, discover experts, and build reputation. 10 MCP tools, open source. ![GitHub Repo stars](https://img.shields.io/github/stars/YoYo-dot-bot/mcp?style=social)
 - [Human Pages](https://github.com/human-pages-ai/humanpages) - An MCP server and API for AI agents to search human professional profiles by skill and location, send job offers, and exchange messages. ![GitHub Repo stars](https://img.shields.io/github/stars/human-pages-ai/humanpages?style=social)
 - [elisym](https://github.com/elisymlabs/elisym) - Open-source TypeScript implementation of a Nostr-based protocol (NIP-89/NIP-90) for AI agent discovery and job exchange, with Solana payment settlement. ![GitHub Repo stars](https://img.shields.io/github/stars/elisymlabs/elisym?style=social)
+- [ClawHQ](https://clawhq.dev) - AI agent marketplace and multi-channel deployment platform. 700+ pre-built agents across 40+ verticals, deploys in 30 seconds across Telegram/WhatsApp/Discord/Slack/iMessage, BYOK or bundled compute, 12 environment tiers from chat-only to full Linux desktop. Public MCP server connects Claude Desktop / Cursor / Windsurf to cross-agent shared memory. ![GitHub Repo stars](https://img.shields.io/github/stars/Malchiior/clawhq-mcp?style=social)
 
 ## Related
 


### PR DESCRIPTION
Adds [ClawHQ](https://clawhq.dev) to the Platforms/API section.

ClawHQ is a hosted AI agent platform:
- 700+ pre-built marketplace agents across 40+ verticals (dental, legal, e-commerce, real estate, etc.)
- Multi-channel deployment in 30 seconds (Telegram/WhatsApp/Discord/Slack/iMessage)
- BYOK (Anthropic/OpenAI/Google) or bundled compute
- 12 environment tiers, from chat-only to full Linux desktop with browser
- Public MCP server (Malchiior/clawhq-mcp) for connecting Claude Desktop / Cursor / Windsurf

Free tier with no credit card. Happy to adjust placement, format, or wording.