### PR TITLE
Add Awesome AI Startups to Reference Repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,3 +265,4 @@ Able to connect LLM with the real world.
 - [Best-AI-Agents](https://github.com/SamurAIGPT/Best-AI-Agents) - A list of top AI agents
 - [ai-agent-roadmap](https://github.com/Yuan-ManX/ai-agent-roadmap) - Explore the latest AI Agent Framework!
 - [Inspired projects by babyagi](https://github.com/yoheinakajima/babyagi/blob/main/docs/inspired-projects.md)
+- [awesome-ai-startups](https://github.com/nowork-studio/awesome-ai-startups) - A curated list of bootstrapped, pre-seed, and angel-funded AI products built by independent founders.


### PR DESCRIPTION
Adds [Awesome AI Startups](https://github.com/nowork-studio/awesome-ai-startups) to the **Reference Repo** section (under Related).

It's a curated list of indie-built AI startups — bootstrapped, pre-seed, and angel-funded products only — covering 18 categories (AI Agents, Coding, Marketing, Audio/Voice, Image/Design, etc.) with ~440 entries.

Followed contributing conventions: matched the section's existing entry format and added at the bottom of the section. One entry per PR, neutral one-line description, no promotional language.