### PR TITLE
Add NotFair (Google Ads MCP)

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Exploring endless possibilities with open-source agent social simulation.
 - [AgentSkeptic](https://github.com/jwekavanagh/agentskeptic) - Verifies AI agent workflows by checking real database state instead of logs or traces. ![GitHub Repo stars](https://img.shields.io/github/stars/jwekavanagh/agentskeptic?style=social)
 - [KubeStellar Console](https://github.com/kubestellar/console) - Multi-cluster Kubernetes dashboard with AI operations agent (kc-agent) that bridges LLMs to live clusters via MCP for AI-assisted troubleshooting, observability, and management across edge and cloud. CNCF Sandbox project. ![GitHub Repo stars](https://img.shields.io/github/stars/kubestellar/console?style=social)
 - [Agent-Wiz](https://github.com/Repello-AI/Agent-Wiz) - Python CLI by Repello AI for extracting agentic workflows from LangChain/LangGraph/CrewAI/AutoGen and running automated threat modeling against the resulting graphs. ![GitHub Repo stars](https://img.shields.io/github/stars/Repello-AI/Agent-Wiz?style=social)
+- [NotFair](https://github.com/nowork-studio/toprank) - Google Ads MCP server for AI agents. Connects Claude or Cursor to a Google Ads account: diagnose campaign performance (CPA, ROAS, search-term waste, quality scores), recommend optimizations, and execute approved changes via the Google Ads API. ![GitHub Repo stars](https://img.shields.io/github/stars/nowork-studio/toprank?style=social)
 
 ## Frameworks
 


### PR DESCRIPTION
Adding NotFair under Applications / Tools. It's a Google Ads MCP server for AI agents — connects Claude or Cursor to a Google Ads account: diagnose campaign performance, recommend optimizations, and execute approved changes via the Google Ads API.

Note: there's already a Toprank entry from the same org; NotFair is a separate, complementary product (Toprank is the SEO/SEM Claude plugin, NotFair is the Google Ads MCP server). Listed in the official MCP registry as io.github.nowork-studio/notfair.

Happy to adjust placement if you'd prefer a different section.