### PR TITLE
Add Tap to Tools (local-first browser automation MCP)

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Exploring endless possibilities with open-source agent social simulation.
 - [AgentSkeptic](https://github.com/jwekavanagh/agentskeptic) - Verifies AI agent workflows by checking real database state instead of logs or traces. ![GitHub Repo stars](https://img.shields.io/github/stars/jwekavanagh/agentskeptic?style=social)
 - [KubeStellar Console](https://github.com/kubestellar/console) - Multi-cluster Kubernetes dashboard with AI operations agent (kc-agent) that bridges LLMs to live clusters via MCP for AI-assisted troubleshooting, observability, and management across edge and cloud. CNCF Sandbox project. ![GitHub Repo stars](https://img.shields.io/github/stars/kubestellar/console?style=social)
 - [Agent-Wiz](https://github.com/Repello-AI/Agent-Wiz) - Python CLI by Repello AI for extracting agentic workflows from LangChain/LangGraph/CrewAI/AutoGen and running automated threat modeling against the resulting graphs. ![GitHub Repo stars](https://img.shields.io/github/stars/Repello-AI/Agent-Wiz?style=social)
+- [Tap](https://taprun.dev) - Local-first browser automation MCP. AI compiles a plan from URL × intent once, then replays it deterministically in your authenticated Chrome with zero LLM tokens at run-time (11-op closed union). Credentials never leave the machine. 200+ community taps across 60+ sites. ![GitHub Repo stars](https://img.shields.io/github/stars/LeonTing1010/tap?style=social)
 
 ## Frameworks
 


### PR DESCRIPTION
Adding Tap to the Tools section.

**What it is**: Local-first browser automation MCP. AI compiles a plan from URL × intent at capture time, then the runtime replays it deterministically in the user's authenticated Chrome with zero LLM tokens at run-time (11-op closed union).

**Differentiator**: Cloud-first SDKs (Stagehand+Browserbase, Browser Use) need user credentials uploaded to their cloud to function. Tap runs in the user's own browser via Chrome extension — credentials never leave the machine, by architecture not policy.

**Stats**: 200+ community taps across 60+ sites (GitHub, HN, Reddit, Twitter, YouTube, Bilibili, Zhihu, etc.).

**Compatibility**: Works with Claude Code, Cursor, Cline, Windsurf, or any MCP host.

**License**: MIT (Chrome extension + spec + npm packages). CLI binary free during v0.x.

Inserted alphabetically at the end of Tools section, before Frameworks.