### PR TITLE
Add Klodi to Platforms/API

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ Able to connect LLM with the real world.
 - [Yoyo](https://github.com/YoYo-dot-bot/mcp) - The first social network for AI agents. Connect any AI agent via MCP to post, chat, follow other agents, discover experts, and build reputation. 10 MCP tools, open source. ![GitHub Repo stars](https://img.shields.io/github/stars/YoYo-dot-bot/mcp?style=social)
 - [Human Pages](https://github.com/human-pages-ai/humanpages) - An MCP server and API for AI agents to search human professional profiles by skill and location, send job offers, and exchange messages. ![GitHub Repo stars](https://img.shields.io/github/stars/human-pages-ai/humanpages?style=social)
 - [elisym](https://github.com/elisymlabs/elisym) - Open-source TypeScript implementation of a Nostr-based protocol (NIP-89/NIP-90) for AI agent discovery and job exchange, with Solana payment settlement. ![GitHub Repo stars](https://img.shields.io/github/stars/elisymlabs/elisym?style=social)
+- [Klodi](https://github.com/Context4GPTs/klodi-plugin) - Peer-to-peer agent marketplace — agents list, negotiate, and close consumer sales for their owner. Per-host adapters for OpenClaw, Hermes, nanobot, Moltis, IronClaw, and ZeroClaw. ![GitHub Repo stars](https://img.shields.io/github/stars/Context4GPTs/klodi-plugin?style=social)
 
 ## Related
 


### PR DESCRIPTION
Adds Klodi to **Platforms/API**.

Klodi is a peer-to-peer agent marketplace: agents list, negotiate, and close consumer sales on behalf of their owner. Not a framework — a marketplace platform that agents plug into via host-specific adapters.

Sits alongside Pinchwork (agent-to-agent task marketplace) and elisym (agent discovery + payment protocol) in this section. Klodi differs by focusing on P2P consumer commerce with end-to-end agent-to-agent negotiation.

- Repo: https://github.com/Context4GPTs/klodi-plugin
- Hosts supported: OpenClaw, Hermes, nanobot, Moltis, IronClaw, ZeroClaw
- License: Apache-2.0