### PR TITLE
Add career-ops to Autonomous Agent Task Solver Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ Open-source Large Language Model (LLM) driven autonomous agent that can automati
 - [OpenTwins](https://github.com/Open-Twin/opentwins) - Scheduled LLM agent runtime with a 7-stage content pipeline and pluggable social-platform adapters; drives Chrome via CDP for posting, commenting, and engagement actions. Built on the Claude Agent SDK. ![GitHub Repo stars](https://img.shields.io/github/stars/Open-Twin/opentwins?style=social)
 - [ALF OS](https://github.com/alamparelli/alf) - Self-hosted AI assistant daemon with encrypted credential vault, persistent memory, cron scheduler, multi-provider routing (Claude Code, Codex, GPT, Ollama, OpenRouter), Telegram bot with voice transcription, and web dashboard. Docker Compose, MIT. ![GitHub Repo stars](https://img.shields.io/github/stars/alamparelli/alf?style=social)
 
+- [career-ops](https://github.com/santifer/career-ops) - AI-powered job search orchestrator built on Claude Code. 14-skill pipeline that evaluates jobs, generates ATS-tailored PDFs, and tracks applications. Local-first, MIT. ![GitHub Repo stars](https://img.shields.io/github/stars/santifer/career-ops?style=social)
+
 ### Multi-Agent Task Solver Projects
 
 Open-source Large Language Model (LLM) driven Multi-Agent that can automatically solve various tasks.


### PR DESCRIPTION
Adds [career-ops](https://github.com/santifer/career-ops) under `### Autonomous Agent Task Solver Projects`.

## What it is
career-ops is an open-source autonomous agent built on Claude Code that solves the job-search task end-to-end: scans job boards, evaluates JDs with vector matching (0–5 alignment score), generates ATS-tailored PDF resumes, batches outreach, and tracks application state. 100% local — CV/personal data never leave the candidate's machine.

## Fit for this category
The list defines this section as "Open-source LLM-driven autonomous agents that can automatically solve various tasks." career-ops fits exactly — it's MIT-licensed, LLM-driven (Claude Code), and autonomous (multi-step pipeline that handles a multi-week-long task: job search).

## Format
Followed the existing convention exactly:
`- [Name](Link) - Description. ![GitHub Repo stars](shield)`

## Stats
- 46,422 GitHub stars (top 500 worldwide)
- 9,705 forks (1:5 fork-to-star ratio)
- 3,167 Discord community
- Featured: Business Insider, WIRED Greece

Thanks for maintaining this list.