### PR TITLE
Add Alfred to Autonomous Agent Task Solver Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Open-source Large Language Model (LLM) driven autonomous agent that can automati
 - [InkOS](https://github.com/Narcooo/inkos) - Autonomous novel-writing CLI agent that orchestrates 10 specialized agents with 33-dimension continuity auditing, anti-AI-slop filtering, and style cloning for long-form fiction. ![GitHub Repo stars](https://img.shields.io/github/stars/Narcooo/inkos?style=social)
 - [OpenTwins](https://github.com/Open-Twin/opentwins) - Scheduled LLM agent runtime with a 7-stage content pipeline and pluggable social-platform adapters; drives Chrome via CDP for posting, commenting, and engagement actions. Built on the Claude Agent SDK. ![GitHub Repo stars](https://img.shields.io/github/stars/Open-Twin/opentwins?style=social)
 - [ALF OS](https://github.com/alamparelli/alf) - Self-hosted AI assistant daemon with encrypted credential vault, persistent memory, cron scheduler, multi-provider routing (Claude Code, Codex, GPT, Ollama, OpenRouter), Telegram bot with voice transcription, and web dashboard. Docker Compose, MIT. ![GitHub Repo stars](https://img.shields.io/github/stars/alamparelli/alf?style=social)
+- [Alfred](https://github.com/luminik-io/alfred-os) - Self-hosted runtime for autonomous Claude Code and Codex agents that turns GitHub issues into reviewed pull requests. Per-firing git worktrees, label-driven state, role-based engine routing, Slack reports. Python, MIT, macOS/Linux. ![GitHub Repo stars](https://img.shields.io/github/stars/luminik-io/alfred-os?style=social)
 
 ### Multi-Agent Task Solver Projects
 


### PR DESCRIPTION
Adds Alfred, a self-hosted runtime that turns GitHub issues into reviewed pull requests through autonomous Claude Code and Codex agents. MIT, Python, macOS/Linux.

### Where it goes
Section: Applications -> Autonomous Agent Task Solver Projects. Added after ALF OS to match the section's narrative ordering (latest entries appended to the bottom).

### Why it fits the section scope
The section is for open-source LLM-driven autonomous agents that solve tasks. Alfred sits next to peers like ALF OS, Octopal, OpenTwins, SWE-agent, and Cline that also run local agent loops driven by LLM CLIs. Specifically Alfred:
- Runs autonomous engineering agents on a host you control, not in a hosted cloud.
- Drives Claude Code and Codex CLIs on your existing subscription, with no provider API keys required.
- Uses GitHub issues and specs as scoped intake, runs each firing in a fresh git worktree, and reports back via Slack.
- Coordinates multi-role agents (planner, implementer, reviewer, tester) through GitHub labels rather than a proprietary control plane.

### Compliance with CONTRIBUTING.md
- One entry per PR.
- Neutral, factual one-sentence description; no hype.
- Existing list line format preserved (name, GitHub link, description, dynamic GitHub stars badge).
- Open source (MIT).
- Active repo with complete README, install guide, and architecture docs at https://alfred.luminik.io.
- Not a duplicate (searched the list).

### Sources
- https://github.com/luminik-io/alfred-os
- https://alfred.luminik.io/