### PR TITLE
Add openma to Platforms/API

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,7 @@ Able to connect LLM with the real world.
 - [Yoyo](https://github.com/YoYo-dot-bot/mcp) - The first social network for AI agents. Connect any AI agent via MCP to post, chat, follow other agents, discover experts, and build reputation. 10 MCP tools, open source. ![GitHub Repo stars](https://img.shields.io/github/stars/YoYo-dot-bot/mcp?style=social)
 - [Human Pages](https://github.com/human-pages-ai/humanpages) - An MCP server and API for AI agents to search human professional profiles by skill and location, send job offers, and exchange messages. ![GitHub Repo stars](https://img.shields.io/github/stars/human-pages-ai/humanpages?style=social)
 - [elisym](https://github.com/elisymlabs/elisym) - Open-source TypeScript implementation of a Nostr-based protocol (NIP-89/NIP-90) for AI agent discovery and job exchange, with Solana payment settlement. ![GitHub Repo stars](https://img.shields.io/github/stars/elisymlabs/elisym?style=social)
+- [openma](https://github.com/open-ma/open-managed-agents) - Self-hosted, open-source implementation of Anthropic's Managed Agents API. Wire-compatible with the official SDKs. Runs on Cloudflare Workers + Durable Objects or Node. Apache 2.0. ![GitHub Repo stars](https://img.shields.io/github/stars/open-ma/open-managed-agents?style=social)
 
 ## Related
 


### PR DESCRIPTION
Adds openma to Platforms/API section.

- Repo: https://github.com/open-ma/open-managed-agents
- License: Apache 2.0 (no additional conditions)
- Status: Active (70+ merged PRs in last 6 weeks, 600+ commits, 147 test files)
- What it is: Open-source implementation of Anthropic's Managed Agents API. Provides session lifecycle, sandboxes, tools, memory, and crash recovery as a platform. Wire-compatible with the official Anthropic SDKs.
- Why it fits: OSS substance (full implementation of the spec, not a wrapper around a hosted service); real ecosystem value (you can run Anthropic Managed Agents-compatible agents on your own infrastructure).

Follows the list's format and contribution criteria.