### PR TITLE
Add Ontheia to Platforms/API section

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,7 @@ Able to connect LLM with the real world.
 - [Human Pages](https://github.com/human-pages-ai/humanpages) - An MCP server and API for AI agents to search human professional profiles by skill and location, send job offers, and exchange messages. ![GitHub Repo stars](https://img.shields.io/github/stars/human-pages-ai/humanpages?style=social)
 - [elisym](https://github.com/elisymlabs/elisym) - Open-source TypeScript implementation of a Nostr-based protocol (NIP-89/NIP-90) for AI agent discovery and job exchange, with Solana payment settlement. ![GitHub Repo stars](https://img.shields.io/github/stars/elisymlabs/elisym?style=social)
 - [openma](https://github.com/open-ma/open-managed-agents) - Self-hosted, open-source implementation of Anthropic's Managed Agents API. Wire-compatible with the official SDKs. Runs on Cloudflare Workers + Durable Objects or Node. Apache 2.0. ![GitHub Repo stars](https://img.shields.io/github/stars/open-ma/open-managed-agents?style=social)
+- [Ontheia](https://github.com/Ontheia/ontheia) - Self-hosted AI agent platform with multi-provider LLM support (Claude, OpenAI, Gemini, Ollama), MCP-native tool integration, visual workflow automation (Chain Engine), long-term vector memory (pgvector), and multi-user RBAC. AGPL-3.0. ![GitHub Repo stars](https://img.shields.io/github/stars/Ontheia/ontheia?style=social)
 
 ## Related
 


### PR DESCRIPTION
Single entry addition to the **Platforms/API** section.

[Ontheia](https://github.com/Ontheia/ontheia) is a self-hosted, open-source AI agent platform:
- Multi-provider LLM support: Claude, OpenAI, Gemini, Ollama
- MCP-native tool integration
- Visual workflow automation (Chain Engine)
- Long-term vector memory with pgvector
- Multi-user RBAC, Docker-based deployment
- License: AGPL-3.0