### PR TITLE
Add GenOps Framework to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ Exploring endless possibilities with open-source agent social simulation.
 - [AgentSkeptic](https://github.com/jwekavanagh/agentskeptic) - Verifies AI agent workflows by checking real database state instead of logs or traces. ![GitHub Repo stars](https://img.shields.io/github/stars/jwekavanagh/agentskeptic?style=social)
 - [KubeStellar Console](https://github.com/kubestellar/console) - Multi-cluster Kubernetes dashboard with AI operations agent (kc-agent) that bridges LLMs to live clusters via MCP for AI-assisted troubleshooting, observability, and management across edge and cloud. CNCF Sandbox project. ![GitHub Repo stars](https://img.shields.io/github/stars/kubestellar/console?style=social)
 - [Agent-Wiz](https://github.com/Repello-AI/Agent-Wiz) - Python CLI by Repello AI for extracting agentic workflows from LangChain/LangGraph/CrewAI/AutoGen and running automated threat modeling against the resulting graphs. ![GitHub Repo stars](https://img.shields.io/github/stars/Repello-AI/Agent-Wiz?style=social)
+- [GenOps Framework](https://github.com/neerazz/genops-framework) - Governance-first Python framework for embedding generative AI agents into CI/CD pipelines: risk scoring, autonomy gates, staged canary rollouts, rollback, and immutable audit trails so agents act as governed deployment actors rather than unbounded assistants. ![GitHub Repo stars](https://img.shields.io/github/stars/neerazz/genops-framework?style=social)
 
 ## Frameworks
 


### PR DESCRIPTION
Adds **GenOps Framework** to the **Tools** section.

GenOps is an open-source (MIT), Python governance-first framework for embedding generative AI agents into CI/CD pipelines — risk scoring, autonomy gates, staged canary rollouts, rollback, and immutable audit trails so agents act as governed deployment actors rather than unbounded assistants. It fits alongside the existing agent-governance/guardrail tools in this section (Agent OS, AgentGuard, Agentic Radar, Kontext CLI).

- Repo: https://github.com/neerazz/genops-framework
- Peer-reviewed: JISEM 2026, DOI [10.52783/jisem.v11i1s.14322](https://doi.org/10.52783/jisem.v11i1s.14322)

Entry follows the existing one-line `[Name](link) - Description. ![stars badge]` format. Thanks for maintaining this list!
