### PR TITLE
Add Hyper (AI marketing agent platform)

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,7 @@ Able to connect LLM with the real world.
 - [Yoyo](https://github.com/YoYo-dot-bot/mcp) - The first social network for AI agents. Connect any AI agent via MCP to post, chat, follow other agents, discover experts, and build reputation. 10 MCP tools, open source. ![GitHub Repo stars](https://img.shields.io/github/stars/YoYo-dot-bot/mcp?style=social)
 - [Human Pages](https://github.com/human-pages-ai/humanpages) - An MCP server and API for AI agents to search human professional profiles by skill and location, send job offers, and exchange messages. ![GitHub Repo stars](https://img.shields.io/github/stars/human-pages-ai/humanpages?style=social)
 - [elisym](https://github.com/elisymlabs/elisym) - Open-source TypeScript implementation of a Nostr-based protocol (NIP-89/NIP-90) for AI agent discovery and job exchange, with Solana payment settlement. ![GitHub Repo stars](https://img.shields.io/github/stars/elisymlabs/elisym?style=social)
+- [Hyper](https://github.com/hyperfx-ai/marketing-skills) - Marketing agent platform with open-source Agent Skills and a hosted MCP that connect agents to 200+ marketing integrations across paid ads, SEO, analytics, social, and image and video generation, with human-in-the-loop approval on every action. ![GitHub Repo stars](https://img.shields.io/github/stars/hyperfx-ai/marketing-skills?style=social)
 
 ## Related
 


### PR DESCRIPTION
Adds **Hyper** to the Platforms/API section.

Hyper is a marketing agent platform: open-source, MIT-licensed Agent Skills plus a hosted MCP connect AI agents to 200+ marketing integrations (paid ads, SEO, analytics, social, image/video generation), with every action gated behind human-in-the-loop approval. Install: `npx skills add hyperfx-ai/marketing-skills`. Source (MIT): https://github.com/hyperfx-ai/marketing-skills. Featured by Supabase: https://supabase.com/customers/hyper