### PR TITLE
Add AgentLoop under Frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ Quickly build and customize agents.
 ![https://arxiv.org/abs/2308.08155](images/autogen_agentchat.png)
 
 - [agent-express](https://github.com/agent-express-ai/agent-express) - Middleware framework for AI agents in TypeScript. Express.js-style (ctx, next) composable hooks for retry, budget caps, memory compaction, tool approval, and observability. ![GitHub Repo stars](https://img.shields.io/github/stars/agent-express-ai/agent-express?style=social)
-- [AgentLoop](https://github.com/mnifzied-create/agentloop) - A minimal, readable Claude agent starter: the streaming + tool-use loop in ~150 lines on Next.js + the official Anthropic SDK, no framework to learn. ![GitHub Repo stars](https://img.shields.io/github/stars/mnifzied-create/agentloop?style=social)
+- [AgentLoop](https://github.com/mnifzied-create/agentloop) - A Claude agent starter implementing the streaming tool-use loop in ~150 lines on Next.js with the official Anthropic SDK. ![GitHub Repo stars](https://img.shields.io/github/stars/mnifzied-create/agentloop?style=social)
 - [langchain](https://github.com/langchain-ai/langchain) - ⚡ Building applications with LLMs through composability ⚡ ![GitHub Repo stars](https://img.shields.io/github/stars/langchain-ai/langchain?style=social)
     - [awesome-langchain](https://github.com/kyrolabs/awesome-langchain) - 😎 Awesome list of tools and projects with the awesome LangChain framework ![GitHub Repo stars](https://img.shields.io/github/stars/kyrolabs/awesome-langchain?style=social)
 - [llama_index](https://github.com/run-llama/llama_index) - LlamaIndex (formerly GPT Index) is a data framework for your LLM applications ![GitHub Repo stars](https://img.shields.io/github/stars/run-llama/llama_index?style=social)

--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ Quickly build and customize agents.
 ![https://arxiv.org/abs/2308.08155](images/autogen_agentchat.png)
 
 - [agent-express](https://github.com/agent-express-ai/agent-express) - Middleware framework for AI agents in TypeScript. Express.js-style (ctx, next) composable hooks for retry, budget caps, memory compaction, tool approval, and observability. ![GitHub Repo stars](https://img.shields.io/github/stars/agent-express-ai/agent-express?style=social)
+- [AgentLoop](https://github.com/mnifzied-create/agentloop) - A minimal, readable Claude agent starter: the streaming + tool-use loop in ~150 lines on Next.js + the official Anthropic SDK, no framework to learn. ![GitHub Repo stars](https://img.shields.io/github/stars/mnifzied-create/agentloop?style=social)
 - [langchain](https://github.com/langchain-ai/langchain) - ⚡ Building applications with LLMs through composability ⚡ ![GitHub Repo stars](https://img.shields.io/github/stars/langchain-ai/langchain?style=social)
     - [awesome-langchain](https://github.com/kyrolabs/awesome-langchain) - 😎 Awesome list of tools and projects with the awesome LangChain framework ![GitHub Repo stars](https://img.shields.io/github/stars/kyrolabs/awesome-langchain?style=social)
 - [llama_index](https://github.com/run-llama/llama_index) - LlamaIndex (formerly GPT Index) is a data framework for your LLM applications ![GitHub Repo stars](https://img.shields.io/github/stars/run-llama/llama_index?style=social)


### PR DESCRIPTION
Adds [AgentLoop](https://github.com/mnifzied-create/agentloop) to **Frameworks** — a minimal, readable Claude agent starter: the streaming + tool-use loop in ~150 lines on Next.js + the official Anthropic SDK, MIT. It complements the heavier frameworks by being the readable, own-the-loop starting point. Thanks for maintaining the list!