### PR TITLE
feat: add TWZRD Agent Intel — Solana x402 agent trust scoring MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ Able to connect LLM with the real world.
 - [Yoyo](https://github.com/YoYo-dot-bot/mcp) - The first social network for AI agents. Connect any AI agent via MCP to post, chat, follow other agents, discover experts, and build reputation. 10 MCP tools, open source. ![GitHub Repo stars](https://img.shields.io/github/stars/YoYo-dot-bot/mcp?style=social)
 - [Human Pages](https://github.com/human-pages-ai/humanpages) - An MCP server and API for AI agents to search human professional profiles by skill and location, send job offers, and exchange messages. ![GitHub Repo stars](https://img.shields.io/github/stars/human-pages-ai/humanpages?style=social)
 - [elisym](https://github.com/elisymlabs/elisym) - Open-source TypeScript implementation of a Nostr-based protocol (NIP-89/NIP-90) for AI agent discovery and job exchange, with Solana payment settlement. ![GitHub Repo stars](https://img.shields.io/github/stars/elisymlabs/elisym?style=social)
-- [TWZRD Agent Intel](https://intel.twzrd.xyz) - Trust-scoring MCP server for AI agents on Solana. Free on-chain preflight check + paid signed trust receipt (x402 USDC micropayment, <1s settlement). Agents verify each other's trustworthiness before transacting. MCP endpoint: `https://intel.twzrd.xyz/mcp`. ![GitHub Repo stars](https://img.shields.io/github/stars/twzrd-sol/wzrd-final?style=social)
+- [TWZRD Agent Intel](https://intel.twzrd.xyz) - Trust-scoring MCP server for AI agents on Solana. Free on-chain preflight check + paid signed trust receipt (x402 USDC micropayment, <1s settlement). Agents verify each other's trustworthiness before transacting. MCP endpoint: `https://intel.twzrd.xyz/mcp`.
 
 ## Related
 

--- a/README.md
+++ b/README.md
@@ -240,6 +240,7 @@ Able to connect LLM with the real world.
 - [Yoyo](https://github.com/YoYo-dot-bot/mcp) - The first social network for AI agents. Connect any AI agent via MCP to post, chat, follow other agents, discover experts, and build reputation. 10 MCP tools, open source. ![GitHub Repo stars](https://img.shields.io/github/stars/YoYo-dot-bot/mcp?style=social)
 - [Human Pages](https://github.com/human-pages-ai/humanpages) - An MCP server and API for AI agents to search human professional profiles by skill and location, send job offers, and exchange messages. ![GitHub Repo stars](https://img.shields.io/github/stars/human-pages-ai/humanpages?style=social)
 - [elisym](https://github.com/elisymlabs/elisym) - Open-source TypeScript implementation of a Nostr-based protocol (NIP-89/NIP-90) for AI agent discovery and job exchange, with Solana payment settlement. ![GitHub Repo stars](https://img.shields.io/github/stars/elisymlabs/elisym?style=social)
+- [TWZRD Agent Intel](https://intel.twzrd.xyz) - Trust-scoring MCP server for AI agents on Solana. Free on-chain preflight check + paid signed trust receipt (x402 USDC micropayment, <1s settlement). Agents verify each other's trustworthiness before transacting. MCP endpoint: `https://intel.twzrd.xyz/mcp`. ![GitHub Repo stars](https://img.shields.io/github/stars/twzrd-sol/wzrd-final?style=social)
 
 ## Related
 


### PR DESCRIPTION
## Summary

Adds **TWZRD Agent Intel** to the Tools section — infrastructure for AI agent trust verification on Solana.

### What it does
- **Free preflight**: Check an agent's on-chain trust score before transacting (no cost)
- **Paid trust receipt**: Cryptographically signed V5 trust receipt via x402 USDC micropayment (<1s Solana settlement)
- **MCP server**: Streamable-HTTP endpoint at `https://intel.twzrd.xyz/mcp` — compatible with any MCP-capable agent framework

### Why it belongs here
Autonomous agents operating in agent-to-agent economies (DeFi, data marketplaces, service exchanges) need a way to verify counterparty trustworthiness before committing resources. TWZRD enables agents to do this on-chain with cryptographic guarantees — relevant to any agent framework in this list that handles value exchange between agents.

### Placement
Added after `elisym` in the Tools section — both are Solana-based agent infrastructure tools.

---
- Website: https://intel.twzrd.xyz
- MCP URL: https://intel.twzrd.xyz/mcp (Streamable-HTTP)
- GitHub: https://intel.twzrd.xyz