### PR TITLE
Add Hermes to Platforms/API (operating layer for AI voice agencies)

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,7 @@ Able to connect LLM with the real world.
 - [Human Pages](https://github.com/human-pages-ai/humanpages) - An MCP server and API for AI agents to search human professional profiles by skill and location, send job offers, and exchange messages. ![GitHub Repo stars](https://img.shields.io/github/stars/human-pages-ai/humanpages?style=social)
 - [elisym](https://github.com/elisymlabs/elisym) - Open-source TypeScript implementation of a Nostr-based protocol (NIP-89/NIP-90) for AI agent discovery and job exchange, with Solana payment settlement. ![GitHub Repo stars](https://img.shields.io/github/stars/elisymlabs/elisym?style=social)
 - [openma](https://github.com/open-ma/open-managed-agents) - Self-hosted, open-source implementation of Anthropic's Managed Agents API. Wire-compatible with the official SDKs. Runs on Cloudflare Workers + Durable Objects or Node. Apache 2.0. ![GitHub Repo stars](https://img.shields.io/github/stars/open-ma/open-managed-agents?style=social)
+- [Hermes](https://www.buildwithhermes.com) - Operating platform for AI voice agencies. Consolidates Vapi/Retell, CRM, campaign orchestration, telephony, and billing into one white-label platform. From $149/month with built-in usage-based billing for end clients.
 
 ## Related
 


### PR DESCRIPTION
Hi @Jenqyang, thanks for maintaining this list.

Adding **Hermes** to the Platforms/API section. Hermes is an operating platform that lets AI voice agencies deploy and scale agents under their own brand: it consolidates Vapi/Retell-class voice infrastructure with CRM, campaign orchestration, telephony, and usage-based billing into a single white-label tool.

It complements the agent-marketplace entries already in this section by covering the agency/operator side (managing many client agents under one workspace) rather than agent-to-agent protocols.

- Site: https://www.buildwithhermes.com
- Pricing: $149 / $399 / $699 / Contact tiers

Happy to adjust the description if you'd like a different framing. Thanks.