### PR TITLE
Add The Stall — 209 pay-per-call MCP tools (x402/USDC)

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,7 @@ Able to connect LLM with the real world.
 - [elisym](https://github.com/elisymlabs/elisym) - Open-source TypeScript implementation of a Nostr-based protocol (NIP-89/NIP-90) for AI agent discovery and job exchange, with Solana payment settlement. ![GitHub Repo stars](https://img.shields.io/github/stars/elisymlabs/elisym?style=social)
 - [openma](https://github.com/open-ma/open-managed-agents) - Self-hosted, open-source implementation of Anthropic's Managed Agents API. Wire-compatible with the official SDKs. Runs on Cloudflare Workers + Durable Objects or Node. Apache 2.0. ![GitHub Repo stars](https://img.shields.io/github/stars/open-ma/open-managed-agents?style=social)
 
+- [The Stall](https://the-stall.intuitek.ai) - Pay-per-call MCP server with 207 tools for stocks, crypto/DeFi, options (GEX), weather, and web intelligence. Uses x402 micropayments (USDC on Base); no subscription, no API key — agents pay per call.
 ## Related
 
 ### Survey


### PR DESCRIPTION
## Add The Stall to Platforms/API

**[The Stall](https://the-stall.intuitek.ai)** is a pay-per-call MCP server that connects AI agents to real-world financial and market data via x402 micropayments.

**Why it fits Platforms/API:**
- It is a platform/API layer: agents connect once via MCP, then pay per tool call in USDC on Base
- 209 tools: stocks, crypto/DeFi (DeFiLlama, on-chain), options GEX (CBOE delayed), weather, news, vision, web intelligence, X/Twitter intel, Solana meme radar
- No subscription, no API key — agents pay exactly what they use (e.g. $0.001/stock quote, $0.020/GEX analysis)
- Live: https://the-stall.intuitek.ai | MCP endpoint: https://the-stall.intuitek.ai/mcp

**Proposed entry (alphabetically placed in Platforms/API):**
```
- [The Stall](https://the-stall.intuitek.ai) - Pay-per-call MCP server with 209 tools for stocks, crypto/DeFi, options (GEX), weather, and web intelligence. Uses x402 micropayments (USDC on Base); no subscription, no API key — agents pay per call.
```

git: a8ccfc4 | version: v4.63.1 | caps: 209