### PR TITLE
Add DOS (dos-kernel) to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ Exploring endless possibilities with open-source agent social simulation.
 - [KubeStellar Console](https://github.com/kubestellar/console) - Multi-cluster Kubernetes dashboard with AI operations agent (kc-agent) that bridges LLMs to live clusters via MCP for AI-assisted troubleshooting, observability, and management across edge and cloud. CNCF Sandbox project. ![GitHub Repo stars](https://img.shields.io/github/stars/kubestellar/console?style=social)
 - [Agent-Wiz](https://github.com/Repello-AI/Agent-Wiz) - Python CLI by Repello AI for extracting agentic workflows from LangChain/LangGraph/CrewAI/AutoGen and running automated threat modeling against the resulting graphs. ![GitHub Repo stars](https://img.shields.io/github/stars/Repello-AI/Agent-Wiz?style=social)
 - [tsm](https://github.com/ahmedsaid47/tsm) - The tiny SSH-first tmux session manager and dashboard tailored for monitoring AI coding agents. ![GitHub Repo stars](https://img.shields.io/github/stars/ahmedsaid47/tsm?style=social)
+- [DOS (dos-kernel)](https://github.com/anthony-chaudhary/dos-kernel) - Trust kernel for AI agent fleets: verifies an agent's "done" claim from git evidence (never self-report), arbitrates file collisions between concurrent agents, and refuses with structured machine-checkable reasons. CLI + MCP server + Claude Code plugin. ![GitHub Repo stars](https://img.shields.io/github/stars/anthony-chaudhary/dos-kernel?style=social)
 
 ## Frameworks
 


### PR DESCRIPTION
Adds [DOS (dos-kernel)](https://github.com/anthony-chaudhary/dos-kernel) at the bottom of the Tools section, matching the entry format (one line + stars badge).

DOS is an open-source (MIT, Python) trust kernel for fleets of AI agents. Instead of believing an agent's self-report, `dos verify` answers "did this actually ship?" from git history — bytes the agent couldn't have written; `dos arbitrate` referees which agents may touch which files concurrently. Ships a CLI with live fleet TUIs, an MCP server, and a Claude Code plugin. `pip install dos-kernel`; `dos quickstart` is a 60-second demo that catches a staged agent lying about a commit. Nearest neighbors already on the list: AgentSkeptic (state-based verification), CommonGround Kernel (shared substrate).