### PR TITLE
Add Remio

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Exploring endless possibilities with open-source agent social simulation.
 
 ### Tools
 - [mem0](https://github.com/mem0ai/mem0) - Mem0 provides a smart, self-improving memory layer for Large Language Models, enabling personalized AI experiences across applications. ![GitHub Repo stars](https://img.shields.io/github/stars/mem0ai/mem0?style=social)
+- [Remio](https://remio.ai/) - Local-first AI memory and knowledge base desktop app for users and agents. It parses notes, files, webpages, recordings, emails, messages, images, and other sources into local indexes and vectors so agents can retrieve targeted context instead of repeatedly scanning files or loading full documents into prompts.
 - [Agent Brain](https://github.com/kaderosio/agent-brain) - 7-layer cognitive memory system for AI agents with perception gate, dream cycle, and predictive capabilities. Self-hostable via Docker. ![GitHub Repo stars](https://img.shields.io/github/stars/kaderosio/agent-brain?style=social)
 - [codex-profiles](https://github.com/Ducksss/codex-profiles) - Bash CLI for switching OpenAI Codex CLI/Desktop accounts with isolated `CODEX_HOME` profiles. ![GitHub Repo stars](https://img.shields.io/github/stars/Ducksss/codex-profiles?style=social)
 - [Cortex](https://github.com/SKULLFIRE07/cortex-memory) - Persistent AI memory for coding assistants. Auto-captures decisions, patterns, and context across sessions. VSCode extension + CLI + MCP server. ![GitHub Repo stars](https://img.shields.io/github/stars/SKULLFIRE07/cortex-memory?style=social)


### PR DESCRIPTION
Adds Remio to the Tools section as a local-first AI memory and knowledge base desktop app for users and agents.\n\nThe entry focuses on Remio's file/content parsing, local indexing, and vector retrieval so agents can retrieve targeted context without repeatedly scanning files or loading full documents into prompts.\n\nWebsite: https://remio.ai/