### PR TITLE
Add Octomind - AI agent runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ Exploring endless possibilities with open-source agent social simulation.
 
 - [clideck](https://github.com/rustykuntz/clideck) - WhatsApp-like dashboard for managing multiple AI coding agents in one browser window. Live status, session resume, autopilot that routes work between agents, and mobile remote. ![GitHub Repo stars](https://img.shields.io/github/stars/rustykuntz/clideck?style=social)
 - [DexPaprika MCP](https://github.com/coinpaprika/dexpaprika-mcp) - Open-source MCP server for querying decentralized exchange data across 34 blockchains. Exposes pool details, token metadata, OHLCV charts, trade history, and real-time swap streams via SSE. ![GitHub Repo stars](https://img.shields.io/github/stars/coinpaprika/dexpaprika-mcp?style=social)
+- [Octomind](https://github.com/muvon/octomind) - Open-source, model-agnostic AI agent runtime with community tap registry (developer:rust, doctor:blood, lawyer:contracts, devops:kubernetes, finance:analyst, security:owasp), MCP support with runtime self-extension, 13+ providers, and adaptive compression. Install agents, not frameworks. [octomind.run](https://octomind.run) ![GitHub Repo stars](https://img.shields.io/github/stars/muvon/octomind?style=social)
 
 ## Frameworks
 


### PR DESCRIPTION
## Adding Octomind

[Octomind](https://octomind.run) is an open-source, model-agnostic AI agent runtime written in Rust.

**Why it fits Awesome-AI-Agents:**
- Model-agnostic runtime — works with 13+ AI providers
- Community tap registry for specialist agents (developer:rust, doctor:blood, lawyer:contracts, devops:kubernetes, finance:analyst, security:owasp)
- MCP support with runtime self-extension
- Adaptive compression for smart context management
- Zero config, single binary — `brew install muvon/tap/octomind`, `cargo install octomind`, or curl
- Apache 2.0 licensed

Added under **Tools** section as an agent runtime (not a framework).

---
*Repo: [Muvon/octomind](https://github.com/muvon/octomind) · Website: [octomind.run](https://octomind.run)*