### PR TITLE
Add rag-architect reference repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,4 +291,5 @@ Able to connect LLM with the real world.
 - [awesome-ai-agents](https://github.com/slavakurilyak/awesome-ai-agents) - Awesome list of 100+ agentic AI resources
 - [Best-AI-Agents](https://github.com/SamurAIGPT/Best-AI-Agents) - A list of top AI agents
 - [ai-agent-roadmap](https://github.com/Yuan-ManX/ai-agent-roadmap) - Explore the latest AI Agent Framework!
+- [rag-architect](https://github.com/greynewell/rag-architect) - Hermes Agent profile and skill pack for designing production RAG agents, evaluation plans, observability specs, and implementation-ready issue templates. ![GitHub Repo stars](https://img.shields.io/github/stars/greynewell/rag-architect?style=social)
 - [Inspired projects by babyagi](https://github.com/yoheinakajima/babyagi/blob/main/docs/inspired-projects.md)


### PR DESCRIPTION
## Summary

Adds [rag-architect](https://github.com/greynewell/rag-architect) to Reference Repo.

## Why it fits

rag-architect is a public Hermes Agent profile and skill pack for designing production RAG agents, evaluation plans, observability specs, and implementation-ready issue templates. It is useful to agent builders who need architecture and planning artifacts around production agentic workflows, rather than another runtime framework.