### PR TITLE
Add Future AGI

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ Benchmarks to evaluate LLM-as-Agent across a variety of environments.
 - [open-operator-evals](https://github.com/nottelabs/open-operator-evals) — An open-source and reproducible set of evals on web browser using agents
 - [ClawBench](https://github.com/reacher-z/ClawBench) - Browser-agent benchmark of 153 everyday tasks on 144 live production websites across 15 categories; a submission-interception layer blocks the final write request for safe evaluation on real sites. ![GitHub Repo stars](https://img.shields.io/github/stars/reacher-z/ClawBench?style=social)
 - [Cross-Agent Review Queue 2026](https://huggingface.co/datasets/neogenesislab/cross-agent-review-queue-2026) - Open dataset of cross-agent collaboration review transcripts (Codex <-> Claude reviewer / architect / implementer handoffs) with structured fields for owner-goal restatement, review lens, and result code (NEW_SIGNAL / NO_NEW_SIGNAL); useful for multi-agent handoff and review-quality evaluation.
+- [Future AGI](https://github.com/future-agi/future-agi) - Open-source platform to simulate, evaluate, trace, guardrail, and optimize LLM and AI agent apps, with 70+ eval metrics and OpenTelemetry-native tracing across 50+ frameworks. ![GitHub Repo stars](https://img.shields.io/github/stars/future-agi/future-agi?style=social)
 
 
 ## Platforms/API


### PR DESCRIPTION
This PR adds Future AGI to this list in the **Benchmark/Evaluator** section.

[Future AGI](https://github.com/future-agi/future-agi) is an open-source (Apache-2.0), self-hostable platform for evaluating, tracing, and guardrailing LLM and AI agent apps, with 70+ eval metrics and LLM-as-judge.

Future AGI is fully open-source and self-hostable; the OSS platform delivers standalone value independent of any paid service.

The entry follows the list's existing format and placement conventions.

Disclosure: I'm affiliated with Future AGI.