### PR TITLE
Add Novu Connect to Platforms/API

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,7 @@ Able to connect LLM with the real world.
 - [Human Pages](https://github.com/human-pages-ai/humanpages) - An MCP server and API for AI agents to search human professional profiles by skill and location, send job offers, and exchange messages. ![GitHub Repo stars](https://img.shields.io/github/stars/human-pages-ai/humanpages?style=social)
 - [elisym](https://github.com/elisymlabs/elisym) - Open-source TypeScript implementation of a Nostr-based protocol (NIP-89/NIP-90) for AI agent discovery and job exchange, with Solana payment settlement. ![GitHub Repo stars](https://img.shields.io/github/stars/elisymlabs/elisym?style=social)
 - [openma](https://github.com/open-ma/open-managed-agents) - Self-hosted, open-source implementation of Anthropic's Managed Agents API. Wire-compatible with the official SDKs. Runs on Cloudflare Workers + Durable Objects or Node. Apache 2.0. ![GitHub Repo stars](https://img.shields.io/github/stars/open-ma/open-managed-agents?style=social)
+- [Novu Connect](https://novu.co/connect) - Agentic communication infrastructure: connect your AI agent to every messaging channel (Slack, Teams, WhatsApp, Telegram, email) with synced threading and in-conversation MCP tools. One CLI: npx novu connect. ![GitHub Repo stars](https://img.shields.io/github/stars/novuhq/novu?style=social)
 
 ## Related
 


### PR DESCRIPTION
Adding **Novu Connect** to the Platforms/API section (alongside KinBot, openma, and other agent-to-real-world platforms).

Novu Connect is agentic communication infrastructure: connect your AI agent to every messaging channel (Slack, Teams, WhatsApp, Telegram, email) with synced conversation threading and in-conversation MCP tools. One CLI: `npx novu connect`. Open source.

- Website: https://novu.co/connect
- Source: https://github.com/novuhq/novu