### PR TITLE
Add LoopTroop to Autonomous Agent Task Solver Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Open-source Large Language Model (LLM) driven autonomous agent that can automati
 - [Alfred](https://github.com/luminik-io/alfred-os) - Self-hosted runtime for autonomous Claude Code and Codex agents that turns GitHub issues into reviewed pull requests. Per-firing git worktrees, label-driven state, role-based engine routing, Slack reports. Python, MIT, macOS/Linux. ![GitHub Repo stars](https://img.shields.io/github/stars/luminik-io/alfred-os?style=social)
 
 - [career-ops](https://github.com/santifer/career-ops) - AI-powered job search orchestrator built on Claude Code. 14-skill pipeline that evaluates jobs, generates ATS-tailored PDFs, and tracks applications. Local-first, MIT. ![GitHub Repo stars](https://img.shields.io/github/stars/santifer/career-ops?style=social)
+- [LoopTroop](https://github.com/looptroop-ai/LoopTroop) - Local GUI orchestrator for AI coding agents where an LLM Council plans, atomic beads execute in isolated git worktrees, and a Ralph Loop retries failures with fresh context. ![GitHub Repo stars](https://img.shields.io/github/stars/looptroop-ai/LoopTroop?style=social)
 
 ### Multi-Agent Task Solver Projects
 


### PR DESCRIPTION
## What

Adding [LoopTroop](https://github.com/looptroop-ai/LoopTroop) to the **Autonomous Agent Task Solver Projects** section.

## Why it belongs

LoopTroop is a local, open-source GUI orchestrator that turns a coding ticket into a merged PR, the same job AutoGPT, OpenDevin, and XAgent do in this section. The distinct part is how it handles long, unattended runs: an LLM Council drafts and votes on the plan, work is split into atomic "beads" that run in isolated git worktrees, and a "Ralph Loop" retries failed beads with a fresh context window instead of continuing a polluted chat. Built on OpenCode (also open-source), MIT licensed, BYOK models, no paid backend dependency.

Neutral one-line description, followed the existing entry format with the stars badge.
