### PR TITLE
Add survey to Related/Survey: Harness Engineering for Language Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,7 @@ Able to connect LLM with the real world.
 - [A Survey on Large Language Model based Autonomous Agents](https://github.com/Paitesanshi/LLM-Agent-Survey) <a href='https://arxiv.org/abs/2308.11432'><img src='https://img.shields.io/badge/Paper-PDF-red'></a>
 - [The Rise and Potential of Large Language Model Based Agents: A Survey](https://github.com/WooooDyy/LLM-Agent-Paper-List) <a href='https://arxiv.org/abs/2309.07864'><img src='https://img.shields.io/badge/Paper-PDF-red'></a>
 - [LLM-Based Human-Agent Collaboration and Interaction Systems: A Survey](https://github.com/HenryPengZou/Awesome-LLM-Based-Human-Agent-System-Papers) <a href='https://arxiv.org/abs/2505.00753'><img src='https://img.shields.io/badge/Paper-PDF-red'></a>
+- [Harness Engineering for Language Agents: The Harness Layer as Control, Agency, and Runtime](https://www.preprints.org/manuscript/202603.1756/v2) <a href='https://doi.org/10.20944/preprints202603.1756'><img src='https://img.shields.io/badge/Paper-PDF-red'></a>
 
 ### Paper-List Repo
 


### PR DESCRIPTION
Adds one survey entry to **Related → Survey** (one entry per PR, neutral one-liner, matching the existing title + Paper-PDF badge style).

**Harness Engineering for Language Agents: The Harness Layer as Control, Agency, and Runtime** (He et al., Preprints 2026) — surveys the agent harness layer, decomposing it into Control, Agency, and Runtime (CAR); audits 63 harness-relevant works; and proposes HarnessCard as a reporting artifact.

Link: https://www.preprints.org/manuscript/202603.1756/v2 (DOI: [10.20944/preprints202603.1756](https://doi.org/10.20944/preprints202603.1756))

Non-GitHub resource, so the title links to the preprint per CONTRIBUTING ("for non-GitHub resources, use the existing section style"). Checked for duplicates; not currently listed.