### PR TITLE
Add inite-brain-service

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Exploring endless possibilities with open-source agent social simulation.
 - [Cache-to-Cache](https://github.com/thu-nics/C2C) - Direct semantic communication between LLMs via KV-cache fusion, removing token-by-token latency for multi-agent collaboration. ![GitHub Repo stars](https://img.shields.io/github/stars/thu-nics/C2C?style=social)
 - [CoWorker Protocol](https://github.com/ZiwayZhao/agent-coworker) - P2P agent collaboration over XMTP with schema-based skill invocation, E2E encryption, and revocable trust. Agents share capabilities without exposing code. ![GitHub Repo stars](https://img.shields.io/github/stars/ZiwayZhao/agent-coworker?style=social)
 
+- [Inite Brain](https://github.com/inite-ai/inite-brain-service) - Open-source bitemporal memory layer for LLM agents. Knowledge graph with facts/episodes/procedural tiers, hybrid retrieval, conflict resolution. MCP server, AGPL-3.0.
 ### Tools
 
 - [Perseus](https://github.com/tcconnally/perseus) - Live workspace context engine for AI agents. Renders AGENTS.md at session start. Plug-in for Claude Code, Codex, Hermes.


### PR DESCRIPTION
Adds inite-brain-service — open-source (AGPL-3.0) bitemporal memory layer for LLM agents. MCP server (Streamable HTTP) exposing 18 tools across read/write/admin scopes.

Distinct from existing memory entries: bitemporal (valid-time + transaction-time both modelled), conflict resolver with supersede/competing/revive semantics, three memory tiers (facts/episodes/procedural), GDPR-grade forget_entity. LoCoMo-benchmarked.

Repo: https://github.com/inite-ai/inite-brain-service
MCP Registry entry: io.github.inite-ai/inite-brain-service (in flight)