### PR TITLE
Add Cynative project to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Exploring endless possibilities with open-source agent social simulation.
 - [Agent-Wiz](https://github.com/Repello-AI/Agent-Wiz) - Python CLI by Repello AI for extracting agentic workflows from LangChain/LangGraph/CrewAI/AutoGen and running automated threat modeling against the resulting graphs. ![GitHub Repo stars](https://img.shields.io/github/stars/Repello-AI/Agent-Wiz?style=social)
 - [tsm](https://github.com/ahmedsaid47/tsm) - The tiny SSH-first tmux session manager and dashboard tailored for monitoring AI coding agents. ![GitHub Repo stars](https://img.shields.io/github/stars/ahmedsaid47/tsm?style=social)
 - [DOS (dos-kernel)](https://github.com/anthony-chaudhary/dos-kernel) - Trust kernel for AI agent fleets: verifies an agent's "done" claim from git evidence (never self-report), arbitrates file collisions between concurrent agents, and refuses with structured machine-checkable reasons. CLI + MCP server + Claude Code plugin. ![GitHub Repo stars](https://img.shields.io/github/stars/anthony-chaudhary/dos-kernel?style=social)
-- [Cynative](https://github.com/cynative/cynative): Agentic security CLI that runs code in a built-in sandbox to research cloud, code and runtime. Read-only by construction. ![GitHub Repo stars](https://img.shields.io/github/stars/cynative/cynative?style=social)
+- [Cynative](https://github.com/cynative/cynative) - Agentic security CLI that runs code in a built-in sandbox to research cloud, code and runtime. Read-only by construction. ![GitHub Repo stars](https://img.shields.io/github/stars/cynative/cynative?style=social)
 
 ## Frameworks
 

--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ Exploring endless possibilities with open-source agent social simulation.
 - [Agent-Wiz](https://github.com/Repello-AI/Agent-Wiz) - Python CLI by Repello AI for extracting agentic workflows from LangChain/LangGraph/CrewAI/AutoGen and running automated threat modeling against the resulting graphs. ![GitHub Repo stars](https://img.shields.io/github/stars/Repello-AI/Agent-Wiz?style=social)
 - [tsm](https://github.com/ahmedsaid47/tsm) - The tiny SSH-first tmux session manager and dashboard tailored for monitoring AI coding agents. ![GitHub Repo stars](https://img.shields.io/github/stars/ahmedsaid47/tsm?style=social)
 - [DOS (dos-kernel)](https://github.com/anthony-chaudhary/dos-kernel) - Trust kernel for AI agent fleets: verifies an agent's "done" claim from git evidence (never self-report), arbitrates file collisions between concurrent agents, and refuses with structured machine-checkable reasons. CLI + MCP server + Claude Code plugin. ![GitHub Repo stars](https://img.shields.io/github/stars/anthony-chaudhary/dos-kernel?style=social)
+- [Cynative](https://github.com/cynative/cynative): Agentic security CLI that runs code in a built-in sandbox to research cloud, code and runtime. Read-only by construction. ![GitHub Repo stars](https://img.shields.io/github/stars/cynative/cynative?style=social)
 
 ## Frameworks
 


### PR DESCRIPTION
## Summary
Adds cynative, an open-source agentic security CLI that runs code in a built-in sandbox to research cloud, code and runtime across AWS, GCP, Azure, Kubernetes, GitHub and GitLab. Read-only enforced by default.

## Type of change
- [x] Add new resource entry
- [ ] Update existing entry
- [ ] Remove outdated/invalid entry
- [ ] Formatting/typo only

## Target section
Specify where this change belongs in `README.md`:
- [ ] Applications / Autonomous Agent Task Solver Projects
- [ ] Applications / Multi-Agent Task Solver Projects
- [ ] Applications / Agent Society Simulation
- [ ] Applications / Advanced Components
- [x] Applications / Tools
- [ ] Frameworks
- [ ] Benchmark/Evaluator
- [ ] Platforms/API
- [ ] Related / Survey
- [ ] Related / Paper-List Repo
- [ ] Related / Blog
- [ ] Reference Repo

## Quality checks (required)
- [x] I searched `README.md` and confirmed this is not a duplicate.
- [x] The submission is relevant to the AI agent ecosystem.
- [x] The description is neutral and evidence-based (not promotional).
- [x] I removed unverifiable claims (e.g., "best", "first") or provided clear evidence.
- [x] If this is open source, license information is clear.
- [x] The linked project/resource has usable documentation (README/docs).
- [x] If this project depends on a paid or closed hosted service, the OSS artifact still has clear standalone value and this PR does not function mainly as service promotion.

## Proposed entry line
```md
- [cynative](https://github.com/cynative/cynative) - Agentic security CLI that runs code in a built-in sandbox to research cloud, code and runtime. Read-only enforced by default. ![GitHub Repo stars](https://img.shields.io/github/stars/cynative/cynative?style=social)
```

## Evidence (optional but recommended)
- Repo + docs: https://github.com/cynative/cynative
- Open source, BYOM (bring-your-own-model), single Go binary; runs entirely in the user's environment.