### PR TITLE
Add Auferet (memory-first AI game master)

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ Exploring endless possibilities with open-source agent social simulation.
 ### Tools
 
 - [Perseus](https://github.com/tcconnally/perseus) - Live workspace context engine for AI agents. Renders AGENTS.md at session start. Plug-in for Claude Code, Codex, Hermes.
+[Auferet](https://auferet.com) - AI game master with persistent memory for your characters and uploaded lore; solo or multiplayer, with 5e and Pathfinder 2e modes.
 
 - [mem0](https://github.com/mem0ai/mem0) - Mem0 provides a smart, self-improving memory layer for Large Language Models, enabling personalized AI experiences across applications. ![GitHub Repo stars](https://img.shields.io/github/stars/mem0ai/mem0?style=social)
 - [Agent Brain](https://github.com/kaderosio/agent-brain) - 7-layer cognitive memory system for AI agents with perception gate, dream cycle, and predictive capabilities. Self-hostable via Docker. ![GitHub Repo stars](https://img.shields.io/github/stars/kaderosio/agent-brain?style=social)


### PR DESCRIPTION
Adds Auferet, an AI game master for solo and multiplayer roleplaying games. It keeps your characters, world, and events in persistent memory and reads lore you upload, so the story stays consistent across long campaigns. Runs 5e and Pathfinder 2e, plays in the browser and on Android, free to start.

Website: https://auferet.com
