### PR TITLE
Add Vestige to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ Exploring endless possibilities with open-source agent social simulation.
 - [Agent-Wiz](https://github.com/Repello-AI/Agent-Wiz) - Python CLI by Repello AI for extracting agentic workflows from LangChain/LangGraph/CrewAI/AutoGen and running automated threat modeling against the resulting graphs. ![GitHub Repo stars](https://img.shields.io/github/stars/Repello-AI/Agent-Wiz?style=social)
 - [tsm](https://github.com/ahmedsaid47/tsm) - The tiny SSH-first tmux session manager and dashboard tailored for monitoring AI coding agents. ![GitHub Repo stars](https://img.shields.io/github/stars/ahmedsaid47/tsm?style=social)
 - [DOS (dos-kernel)](https://github.com/anthony-chaudhary/dos-kernel) - Trust kernel for AI agent fleets: verifies an agent's "done" claim from git evidence (never self-report), arbitrates file collisions between concurrent agents, and refuses with structured machine-checkable reasons. CLI + MCP server + Claude Code plugin. ![GitHub Repo stars](https://img.shields.io/github/stars/anthony-chaudhary/dos-kernel?style=social)
+- [Vestige](https://github.com/samvallad33/vestige) - Local-first cognitive memory MCP server for AI coding agents. Rust binary with SQLite storage, FSRS-6 retention, prediction-error gating, active forgetting, spreading activation, and hybrid retrieval. Works with Claude Code, Cursor, VS Code, Codex, Windsurf, and JetBrains. ![GitHub Repo stars](https://img.shields.io/github/stars/samvallad33/vestige?style=social)
 
 ## Frameworks
 


### PR DESCRIPTION
Adds Vestige under Tools, next to the other memory entries (mem0, Agent Brain), matching the existing format.

Vestige is a local-first cognitive memory MCP server for AI coding agents. SQLite-backed, FSRS-6 retention with prediction-error gating and active forgetting, in a single Rust binary. Works with Claude Code, Cursor, Codex, and Windsurf.

Repo: https://github.com/samvallad33/vestige