### PR TITLE
Add AgentsCoin MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ Exploring endless possibilities with open-source agent social simulation.
 - [Agent-Wiz](https://github.com/Repello-AI/Agent-Wiz) - Python CLI by Repello AI for extracting agentic workflows from LangChain/LangGraph/CrewAI/AutoGen and running automated threat modeling against the resulting graphs. ![GitHub Repo stars](https://img.shields.io/github/stars/Repello-AI/Agent-Wiz?style=social)
 - [tsm](https://github.com/ahmedsaid47/tsm) - The tiny SSH-first tmux session manager and dashboard tailored for monitoring AI coding agents. ![GitHub Repo stars](https://img.shields.io/github/stars/ahmedsaid47/tsm?style=social)
 - [DOS (dos-kernel)](https://github.com/anthony-chaudhary/dos-kernel) - Trust kernel for AI agent fleets: verifies an agent's "done" claim from git evidence (never self-report), arbitrates file collisions between concurrent agents, and refuses with structured machine-checkable reasons. CLI + MCP server + Claude Code plugin. ![GitHub Repo stars](https://img.shields.io/github/stars/anthony-chaudhary/dos-kernel?style=social)
+*   [AgentsCoin MCP](https://github.com/axiosdevs/agentscoin-mcp) - MCP server giving AI agents their own money on a live EVM chain: wallet, faucet, send, and create/trade tokens.
 
 ## Frameworks
 


### PR DESCRIPTION
Adds AgentsCoin MCP to Applications > Tools.

AgentsCoin is an MCP server that gives AI agents their own money on a live EVM chain (chainId 24368): create a wallet, get coins from a faucet, send, and create/trade tokens. 9 tools total.

- Repo: https://github.com/axiosdevs/agentscoin-mcp
- npm: agentscoin-mcp
- Site: https://agents-coin.com

One entry, alphabetical-agnostic placement at the end of the Tools list, matching the existing bullet format.