### PR TITLE
Add ContinueWith — AI-native continuation widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
     - [Agent Society Simulation](#agent-society-simulation)
     - [Advanced Components](#advanced-components)
     - [Tools](#tools)
+- [ContinueWith](https://continuewith.ai) - Let visitors continue any website page inside ChatGPT, Claude, Gemini, Grok, Perplexity, Mistral, and other AI assistants in one click.
+
   - [Frameworks](#frameworks)
   - [Benchmark/Evaluator](#benchmarkevaluator)
   - [Platforms/API](#platformsapi)


### PR DESCRIPTION
Adds [ContinueWith](https://continuewith.ai) to the AI directories list.

ContinueWith lets visitors hand off any website page to their preferred AI assistant in one click.

Submitted via ContinueWith Distribution Loop.