### PR TITLE
Add OpenClaw Monitor - OpenClaw agent monitoring dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ Exploring endless possibilities with open-source agent social simulation.
 - [clideck](https://github.com/rustykuntz/clideck) - WhatsApp-like dashboard for managing multiple AI coding agents in one browser window. Live status, session resume, autopilot that routes work between agents, and mobile remote. ![GitHub Repo stars](https://img.shields.io/github/stars/rustykuntz/clideck?style=social)
 - [DexPaprika MCP](https://github.com/coinpaprika/dexpaprika-mcp) - Open-source MCP server for querying decentralized exchange data across 34 blockchains. Exposes pool details, token metadata, OHLCV charts, trade history, and real-time swap streams via SSE. ![GitHub Repo stars](https://img.shields.io/github/stars/coinpaprika/dexpaprika-mcp?style=social)
 - [Desktop Control](https://github.com/yaroshevych/desktopctl) - CLI tool for AI agents to control macOS apps via screen, mouse, and keyboard. GPU-accelerated, local OCR and vision, works with any AI model. ![GitHub Repo stars](https://img.shields.io/github/stars/yaroshevych/desktopctl?style=social)
+- [OpenClaw Monitor](https://github.com/flik2002/openclaw-monitor) - Free open-source monitoring dashboard for OpenClaw AI agents — token usage, session tracking, 7-day trends, and multi-model support. Vue 3 + ECharts, self-hosted. ![GitHub Repo stars](https://img.shields.io/github/stars/flik2002/openclaw-monitor?style=social)
 
 ## Frameworks
 


### PR DESCRIPTION
## Add OpenClaw Monitor

Free open-source monitoring dashboard for [OpenClaw AI agents](https://github.com/openclaw-ai/openclaw) — token usage, session tracking, 7-day trends, and multi-model support.

- **Stars:** 10
- **Repo:** https://github.com/flik2002/openclaw-monitor
- **Screenshot:** https://raw.githubusercontent.com/flik2002/openclaw-monitor/main/Openclaw%20Monitor.jpg
- **Stack:** Vue 3 + ECharts, self-hosted

This fills a gap in the OpenClaw ecosystem — the only open-source dashboard purpose-built for OpenClaw agent observability.

---

*Submitted via automated promotion script.*