### PR TITLE
Add LiveContext to Platforms/API

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ Able to connect LLM with the real world.
 - [Human Pages](https://github.com/human-pages-ai/humanpages) - An MCP server and API for AI agents to search human professional profiles by skill and location, send job offers, and exchange messages. ![GitHub Repo stars](https://img.shields.io/github/stars/human-pages-ai/humanpages?style=social)
 - [elisym](https://github.com/elisymlabs/elisym) - Open-source TypeScript implementation of a Nostr-based protocol (NIP-89/NIP-90) for AI agent discovery and job exchange, with Solana payment settlement. ![GitHub Repo stars](https://img.shields.io/github/stars/elisymlabs/elisym?style=social)
 - [openma](https://github.com/open-ma/open-managed-agents) - Self-hosted, open-source implementation of Anthropic's Managed Agents API. Wire-compatible with the official SDKs. Runs on Cloudflare Workers + Durable Objects or Node. Apache 2.0. ![GitHub Repo stars](https://img.shields.io/github/stars/open-ma/open-managed-agents?style=social)
+- [LiveContext](https://github.com/livecontext-ai/livecontext-ce) - Self-hosted AI automation platform: describe a job in chat to build a workflow, run it with scoped, budgeted AI agents, and ship it as an app. 600+ integrations, human-approval steps, and an MCP server. Fair-code. ![GitHub Repo stars](https://img.shields.io/github/stars/livecontext-ai/livecontext-ce?style=social)
 
 ## Related
 


### PR DESCRIPTION
Adds **LiveContext** to the Platforms/API section.

LiveContext is a self-hosted AI automation platform: describe a job in chat and it builds a workflow you can read, runs it with AI agents that are scoped and budgeted, and ships it as a small app. 600+ integrations, human-approval steps, and an MCP server. Fair-code (Sustainable Use License), self-hostable with one docker compose up.

- Repo: https://github.com/livecontext-ai/livecontext-ce
- Site: https://livecontext.ai

Thanks for maintaining this list!