### PR TITLE
Add CIAgent to Benchmark/Evaluator

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,7 @@ Benchmarks to evaluate LLM-as-Agent across a variety of environments.
 - [ClawBench](https://github.com/reacher-z/ClawBench) - Browser-agent benchmark of 153 everyday tasks on 144 live production websites across 15 categories; a submission-interception layer blocks the final write request for safe evaluation on real sites. ![GitHub Repo stars](https://img.shields.io/github/stars/reacher-z/ClawBench?style=social)
 - [Cross-Agent Review Queue 2026](https://huggingface.co/datasets/neogenesislab/cross-agent-review-queue-2026) - Open dataset of cross-agent collaboration review transcripts (Codex <-> Claude reviewer / architect / implementer handoffs) with structured fields for owner-goal restatement, review lens, and result code (NEW_SIGNAL / NO_NEW_SIGNAL); useful for multi-agent handoff and review-quality evaluation.
 - [Future AGI](https://github.com/future-agi/future-agi) - Open-source platform to simulate, evaluate, trace, guardrail, and optimize LLM and AI agent apps, with 70+ eval metrics and OpenTelemetry-native tracing across 50+ frameworks. ![GitHub Repo stars](https://img.shields.io/github/stars/future-agi/future-agi?style=social)
+- [CIAgent](https://github.com/suniel12/ciagent) - Pytest-native regression testing for AI agents — golden-trace diffing, cost guardrails, multi-run stability scoring with flip attribution, LLM-judge auditing, and one-command import of production traces (OTel/Langfuse/LangSmith) into CI tests. ![GitHub Repo stars](https://img.shields.io/github/stars/suniel12/ciagent?style=social)
 
 
 ## Platforms/API


### PR DESCRIPTION
Adds **CIAgent** (`pip install ciagent`) — pytest-native regression testing for AI agents: golden-trace recording and diffing, cost guardrails, multi-run stability scoring with verdict-flip attribution, LLM-judge auditing, and one-command import of production traces (OpenTelemetry, Langfuse, LangSmith) into CI tests. Apache-2.0, active development, 900+ tests. Follows the list's format and ordering; one item, one PR.