### PR TITLE
Add awesome-agentic-commerce to Reference Repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,7 @@ Able to connect LLM with the real world.
 - [awesome-ai-agents](https://github.com/e2b-dev/awesome-ai-agents) - A list of AI autonomous agents
 - [awesome-ai-agents](https://github.com/slavakurilyak/awesome-ai-agents) - Awesome list of 100+ agentic AI resources
 - [Best-AI-Agents](https://github.com/SamurAIGPT/Best-AI-Agents) - A list of top AI agents
+- [awesome-agentic-commerce](https://github.com/MentionNetwork/awesome-agentic-commerce) - Curated list for AI agents that shop, sell and transact: UCP/ACP/AP2/MCP protocols, commerce MCP servers and agent readiness tools.
 - [ai-agent-roadmap](https://github.com/Yuan-ManX/ai-agent-roadmap) - Explore the latest AI Agent Framework!
 - [rag-architect](https://github.com/greynewell/rag-architect) - Hermes Agent profile and skill pack for designing production RAG agents, evaluation plans, observability specs, and implementation-ready issue templates. ![GitHub Repo stars](https://img.shields.io/github/stars/greynewell/rag-architect?style=social)
 - [Inspired projects by babyagi](https://github.com/yoheinakajima/babyagi/blob/main/docs/inspired-projects.md)


### PR DESCRIPTION
Adds [awesome-agentic-commerce](https://github.com/MentionNetwork/awesome-agentic-commerce) to the Reference Repo section — a curated list focused on the commerce side of AI agents: checkout/payment protocols (UCP, ACP, AP2), commerce MCP servers (Shopify Storefront MCP, Stripe, Amazon Ads), and store agent-readiness testing tools. Complements the agent frameworks and platforms this list covers with the transactional/commerce domain.