### PR TITLE
Add BrowserBash to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ Exploring endless possibilities with open-source agent social simulation.
 - [tsm](https://github.com/ahmedsaid47/tsm) - The tiny SSH-first tmux session manager and dashboard tailored for monitoring AI coding agents. ![GitHub Repo stars](https://img.shields.io/github/stars/ahmedsaid47/tsm?style=social)
 - [DOS (dos-kernel)](https://github.com/anthony-chaudhary/dos-kernel) - Trust kernel for AI agent fleets: verifies an agent's "done" claim from git evidence (never self-report), arbitrates file collisions between concurrent agents, and refuses with structured machine-checkable reasons. CLI + MCP server + Claude Code plugin. ![GitHub Repo stars](https://img.shields.io/github/stars/anthony-chaudhary/dos-kernel?style=social)
 - [Cynative](https://github.com/cynative/cynative) - Agentic security CLI that runs code in a built-in sandbox to research cloud, code and runtime. Read-only by construction. ![GitHub Repo stars](https://img.shields.io/github/stars/cynative/cynative?style=social)
+- [BrowserBash](https://github.com/PramodDutta/browserbash) - Plain-English browser testing for AI agents; an agent runs objectives or whole test suites in a real Chrome and returns deterministic verdicts (assertions, exit codes). Ships an MCP server. ![GitHub Repo stars](https://img.shields.io/github/stars/PramodDutta/browserbash?style=social)
 
 ## Frameworks
 


### PR DESCRIPTION
Adds **BrowserBash** to Tools (beside Steel Browser / BrowserTrace).

- Repo: https://github.com/PramodDutta/browserbash (Apache-2.0)
- On the official MCP Registry: `io.github.PramodDutta/browserbash`

Plain-English browser testing for AI agents: an agent runs objectives or whole test suites in a real Chrome and returns deterministic verdicts (assertions, CI exit codes). Ships an MCP server so coding agents validate their own UI work. Free local models, no API keys. One-line addition with the stars badge, matching the section.