### PR TITLE
Add autobatcher to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ Exploring endless possibilities with open-source agent social simulation.
 - [tsm](https://github.com/ahmedsaid47/tsm) - The tiny SSH-first tmux session manager and dashboard tailored for monitoring AI coding agents. ![GitHub Repo stars](https://img.shields.io/github/stars/ahmedsaid47/tsm?style=social)
 - [DOS (dos-kernel)](https://github.com/anthony-chaudhary/dos-kernel) - Trust kernel for AI agent fleets: verifies an agent's "done" claim from git evidence (never self-report), arbitrates file collisions between concurrent agents, and refuses with structured machine-checkable reasons. CLI + MCP server + Claude Code plugin. ![GitHub Repo stars](https://img.shields.io/github/stars/anthony-chaudhary/dos-kernel?style=social)
 - [Cynative](https://github.com/cynative/cynative) - Agentic security CLI that runs code in a built-in sandbox to research cloud, code and runtime. Read-only by construction. ![GitHub Repo stars](https://img.shields.io/github/stars/cynative/cynative?style=social)
+- [autobatcher](https://github.com/doublewordai/autobatcher) - Drop-in AsyncOpenAI replacement that transparently batches concurrent requests to improve throughput and reduce latency for high-volume LLM and agent workloads. ![GitHub Repo stars](https://img.shields.io/github/stars/doublewordai/autobatcher?style=social)
 
 ## Frameworks
 


### PR DESCRIPTION
## Summary

Adds `autobatcher` (Doubleword AI) to the Applications / Tools section. It is a drop-in AsyncOpenAI replacement that transparently batches concurrent requests so agents making high-volume LLM calls get better throughput and lower latency.

## Type of change

- [x] Add new resource entry
- [ ] Update existing entry
- [ ] Remove outdated/invalid entry
- [ ] Formatting/typo only

## Target section

- [ ] Applications / Autonomous Agent Task Solver Projects
- [ ] Applications / Multi-Agent Task Solver Projects
- [ ] Applications / Agent Society Simulation
- [ ] Applications / Advanced Components
- [x] Applications / Tools
- [ ] Frameworks
- [ ] Benchmark/Evaluator
- [ ] Platforms/API
- [ ] Related / Survey
- [ ] Related / Paper-List Repo
- [ ] Related / Blog
- [ ] Reference Repo

## Quality checks (required)

- [x] I searched `README.md` and confirmed this is not a duplicate.
- [x] The submission is relevant to the AI agent ecosystem.
- [x] The description is neutral and evidence-based (not promotional).
- [x] I removed unverifiable claims (e.g., "best", "first") or provided clear evidence.
- [x] If this is open source, license information is clear.
- [x] The linked project/resource has usable documentation (README/docs).
- [x] If this project depends on a paid or closed hosted service, the OSS artifact still has clear standalone value and this PR does not function mainly as service promotion.

## Proposed entry line

```md
- [autobatcher](https://github.com/doublewordai/autobatcher) - Drop-in AsyncOpenAI replacement that transparently batches concurrent requests to improve throughput and reduce latency for high-volume LLM and agent workloads. ![GitHub Repo stars](https://img.shields.io/github/stars/doublewordai/autobatcher?style=social)
```

## Evidence

- Repo: https://github.com/doublewordai/autobatcher
- License: MIT (standard OSS, clearly visible in repo metadata).
- Standalone OSS value: `autobatcher` is a self-contained Python library. It is API-compatible with `openai.AsyncOpenAI` and works against any OpenAI-compatible endpoint (OpenAI, self-hosted vLLM/TGI, local models). It does not require any paid or hosted Doubleword product to be useful, so this entry is not a gateway to a commercial service.