### PR TITLE
Add Nora to Platforms/API

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ Able to connect LLM with the real world.
 ![](./images/system_design.png)
 
 - [Agentfield](https://github.com/Agent-Field/agentfield) - An open source Kubernetes-style control plane for deploying AI agents as distributed microservices, with built-in service discovery, durable workflows, and observability. ![GitHub Repo stars](https://img.shields.io/github/stars/Agent-Field/agentfield?style=social)
+- [Nora](https://github.com/solomon2773/nora) - Self-hosted control plane for deploying and operating OpenClaw and Hermes agent fleets on Docker or Kubernetes, with lifecycle controls, monitoring, budgets, schedules, and per-agent cost tracking. ![GitHub Repo stars](https://img.shields.io/github/stars/solomon2773/nora?style=social)
 - [OpenAgents](https://github.com/xlang-ai/OpenAgents) - An Open Platform for Language Agents in the Wild ![GitHub Repo stars](https://img.shields.io/github/stars/xlang-ai/OpenAgents?style=social)
 - [OpenAGI](https://github.com/agiresearch/OpenAGI) - "May the Force be with LLM and Domain Experts." ![GitHub Repo stars](https://img.shields.io/github/stars/agiresearch/OpenAGI?style=social)
 - [RestGPT](https://github.com/Yifan-Song793/RestGPT) - An LLM-based autonomous agent controlling real-world applications via RESTful APIs ![GitHub Repo stars](https://img.shields.io/github/stars/Yifan-Song793/RestGPT?style=social)


### PR DESCRIPTION
Adds Nora to the Platforms/API section.

Nora is an Apache-2.0 self-hosted control plane for OpenClaw and Hermes agent fleets. It deploys and operates runtimes on Docker or Kubernetes and includes lifecycle controls, monitoring, budgets, schedules, and per-agent cost tracking.

Checks:
- Searched the README, issues, and pull requests for an existing Nora entry; none found.
- Confirmed the repository is active, usable without a hosted dependency, and licensed Apache-2.0.
- Kept the change to one neutral entry in the existing list format.
- Confirmed the repository and stars badge URLs return HTTP 200.
- Ran `git diff --check`.

Disclosure: this submission is from the Nora repository owner.