### PR TITLE
Add "When not to build an agent" (Loop & Retry) to Blog

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ Able to connect LLM with the real world.
 - [基于大语言模型的AI Agents](https://www.breezedeus.com/article/ai-agent-part3)
 - [ICLR'24 上大型语言模型代理的最新研究进展 | 代理评估重点](https://medium.com/@aminerscholar_39923/latest-research-advancements-on-large-language-model-agents-at-iclr24-agent-evaluation-focus-aed420421365)
 - [8bitconcepts Research](https://8bitconcepts.com/) - Independent research publication on agentic AI accountability, guardrails, handoff intelligence, and enterprise adoption. Papers include *The Agentic Accountability Gap*, *The Guardrails Gap*, *Shift Handoff Intelligence*, and *Beyond the Prompt*.
-- [When not to build an agent](https://loopandretry.github.io/posts/when-not-to-build-an-agent/?ref=awesome-ai-agents) - A practitioner's decision framework for when a deterministic pipeline beats an autonomous agent, matching each task to the least-powerful reliable tool.
+- [When not to build an agent](https://loopandretry.github.io/posts/when-not-to-build-an-agent/) - A practitioner's decision framework for when a deterministic pipeline beats an autonomous agent, matching each task to the least-powerful reliable tool.
 
 
 ## Reference Repo

--- a/README.md
+++ b/README.md
@@ -303,6 +303,7 @@ Able to connect LLM with the real world.
 - [基于大语言模型的AI Agents](https://www.breezedeus.com/article/ai-agent-part3)
 - [ICLR'24 上大型语言模型代理的最新研究进展 | 代理评估重点](https://medium.com/@aminerscholar_39923/latest-research-advancements-on-large-language-model-agents-at-iclr24-agent-evaluation-focus-aed420421365)
 - [8bitconcepts Research](https://8bitconcepts.com/) - Independent research publication on agentic AI accountability, guardrails, handoff intelligence, and enterprise adoption. Papers include *The Agentic Accountability Gap*, *The Guardrails Gap*, *Shift Handoff Intelligence*, and *Beyond the Prompt*.
+- [When not to build an agent](https://loopandretry.github.io/posts/when-not-to-build-an-agent/?ref=awesome-ai-agents) - A practitioner's decision framework for when a deterministic pipeline beats an autonomous agent, matching each task to the least-powerful reliable tool.
 
 
 ## Reference Repo


### PR DESCRIPTION
Adds one practitioner essay to the Blog section.

Link: https://loopandretry.github.io/posts/when-not-to-build-an-agent/

Why it fits: a decision framework for when a deterministic pipeline beats an autonomous agent — the same agent-architecture lane as the existing Lilian Weng and 8bitconcepts entries. Substantive full essay, formatted to match the existing non-GitHub Blog entries.

Disclosure: I write this blog; submitting because it is genuinely on-topic, not promotional.