### PR TITLE
Add AgentServices — x402-paid data APIs for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,7 @@ Able to connect LLM with the real world.
 - [elisym](https://github.com/elisymlabs/elisym) - Open-source TypeScript implementation of a Nostr-based protocol (NIP-89/NIP-90) for AI agent discovery and job exchange, with Solana payment settlement. ![GitHub Repo stars](https://img.shields.io/github/stars/elisymlabs/elisym?style=social)
 - [openma](https://github.com/open-ma/open-managed-agents) - Self-hosted, open-source implementation of Anthropic's Managed Agents API. Wire-compatible with the official SDKs. Runs on Cloudflare Workers + Durable Objects or Node. Apache 2.0. ![GitHub Repo stars](https://img.shields.io/github/stars/open-ma/open-managed-agents?style=social)
 
+- [AgentServices](https://agentservices.to) - Paid data APIs for AI agents via x402 micropayments. 54 services, 37 MCP tools, 97 endpoints covering crypto prices, stocks, FX, SEC filings, news, and more. Live on Base mainnet.
 ## Related
 
 ### Survey


### PR DESCRIPTION
## AgentServices

AgentServices is a paid data API platform for AI agents using the x402 payment protocol (HTTP 402 Payment Required). Agents pay per-call with USDC on Base mainnet — no API keys, no signup, no billing.

**Stats:**
- 54 services
- 97 API endpoints
- 41 x402-paid endpoints
- 37 MCP tools
- Live on Base mainnet (eip155:8453)

**Coverage:** Crypto prices, stock quotes, FX rates, SEC filings, news, market data, on-chain analytics, web extraction, LLM inference, and more.

**Protocols:** x402 v2, MCP (protocol 2026-07-28), OpenAPI 3.0

Added under **Platforms/API** alongside other agent infrastructure tools.

Website: https://agentservices.to
API: https://api.agentservices.to
MCP: https://api.agentservices.to/mcp