### PR TITLE
Add OpenAgent (ACL 2025)

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Open-source Large Language Model (LLM) driven autonomous agent that can automati
 - [career-ops](https://github.com/santifer/career-ops) - AI-powered job search orchestrator built on Claude Code. 14-skill pipeline that evaluates jobs, generates ATS-tailored PDFs, and tracks applications. Local-first, MIT. ![GitHub Repo stars](https://img.shields.io/github/stars/santifer/career-ops?style=social)
 - [Darkmoon](https://github.com/ASCIT31/Dark-Moon) - Open source autonomous AI penetration testing platform where Markdown methodology agents orchestrate 80+ offensive security tools through MCP controlled execution with agentic reasoning, keeping an evidence trail per finding. Model agnostic, tuned for Claude Opus. ![GitHub Repo stars](https://img.shields.io/github/stars/ASCIT31/Dark-Moon?style=social)
 - [LoopTroop](https://github.com/looptroop-ai/LoopTroop) - Local GUI orchestrator for AI coding agents where an LLM Council plans, atomic beads execute in isolated git worktrees, and a Ralph Loop retries failures with fresh context. ![GitHub Repo stars](https://img.shields.io/github/stars/looptroop-ai/LoopTroop?style=social)
+- [OpenAgent (OpenAct)](https://github.com/OpenBMB/OpenAct) - LLM agent system that autonomously integrates specialized tools from GitHub repositories to solve open-domain tasks. ![GitHub Repo stars](https://img.shields.io/github/stars/OpenBMB/OpenAct?style=social)
 
 ### Multi-Agent Task Solver Projects
 


### PR DESCRIPTION
Paper: **Enhancing Open-Domain Task-Solving Capability of LLMs via Autonomous Tool Integration from GitHub** (ACL 2025 main conference)

- arXiv: https://arxiv.org/abs/2312.17294
- Code: https://github.com/OpenBMB/OpenAct

The paper introduces OpenAgent, an LLM-based agent system that solves open-domain tasks by autonomously integrating specialized tools from GitHub repositories, which fits the **Autonomous Agent Task Solver Projects** section (alongside systems like JARVIS and XAgent).

Note: this is a different project from the existing `OpenAgent` (the-open-agent/openagent) and `OpenAgents` (xlang-ai, openagents-org) entries, so the entry is labeled `OpenAgent (OpenAct)` to disambiguate.