### PR TITLE
Add BenchGen to Benchmark/Evaluator section

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,7 @@ Benchmarks to evaluate LLM-as-Agent across a variety of environments.
 - [Cross-Agent Review Queue 2026](https://huggingface.co/datasets/neogenesislab/cross-agent-review-queue-2026) - Open dataset of cross-agent collaboration review transcripts (Codex <-> Claude reviewer / architect / implementer handoffs) with structured fields for owner-goal restatement, review lens, and result code (NEW_SIGNAL / NO_NEW_SIGNAL); useful for multi-agent handoff and review-quality evaluation.
 - [Future AGI](https://github.com/future-agi/future-agi) - Open-source platform to simulate, evaluate, trace, guardrail, and optimize LLM and AI agent apps, with 70+ eval metrics and OpenTelemetry-native tracing across 50+ frameworks. ![GitHub Repo stars](https://img.shields.io/github/stars/future-agi/future-agi?style=social)
 - [CIAgent](https://github.com/suniel12/ciagent) - Pytest-native regression testing for AI agents — golden-trace diffing, cost guardrails, multi-run stability scoring with flip attribution, LLM-judge auditing, and one-command import of production traces (OTel/Langfuse/LangSmith) into CI tests. ![GitHub Repo stars](https://img.shields.io/github/stars/suniel12/ciagent?style=social)
+- [BenchGen](https://benchgen.com) - AI agent benchmarking and evaluation platform. Runs structured benchmark suites and scores agents across tool-call accuracy, goal completion, and skill coverage — then exports filtered trajectories for fine-tuning.
 
 
 ## Platforms/API


### PR DESCRIPTION
Hi! I'd like to add BenchGen (https://benchgen.com) to the Benchmark/Evaluator section.

It's an AI agent benchmarking and evaluation platform — runs structured benchmark suites against your agents and scores performance across tool-call accuracy, goal completion, and skill coverage. It also exports filtered trajectory data for fine-tuning. Seems like a great fit alongside AgentBench, agentops, and the other evaluators in that section.

Happy to adjust the description if needed.