### PR TITLE
Add Caspian to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ Exploring endless possibilities with open-source agent social simulation.
 - [DOS (dos-kernel)](https://github.com/anthony-chaudhary/dos-kernel) - Trust kernel for AI agent fleets: verifies an agent's "done" claim from git evidence (never self-report), arbitrates file collisions between concurrent agents, and refuses with structured machine-checkable reasons. CLI + MCP server + Claude Code plugin. ![GitHub Repo stars](https://img.shields.io/github/stars/anthony-chaudhary/dos-kernel?style=social)
 - [Cynative](https://github.com/cynative/cynative) - Agentic security CLI that runs code in a built-in sandbox to research cloud, code and runtime. Read-only by construction. ![GitHub Repo stars](https://img.shields.io/github/stars/cynative/cynative?style=social)
 - [Nika](https://github.com/supernovae-st/nika) - Intent-as-code workflow engine for AI agents: reviewable YAML DAGs statically checked (schema, permits, honest cost floor) before any token is spent, tamper-evident traces after. Single Rust binary. ![GitHub Repo stars](https://img.shields.io/github/stars/supernovae-st/nika?style=social)
+- [Caspian](https://github.com/TryCaspian/caspian-sdk) - One messaging identity for an AI agent across Slack, Discord, Telegram, Instagram, email, and X — a single `on_message` handler with threading, webhook verification, and platform quirks handled. Python + TypeScript SDK. ![GitHub Repo stars](https://img.shields.io/github/stars/TryCaspian/caspian-sdk?style=social)
 
 ## Frameworks
 


### PR DESCRIPTION
Adds [Caspian](https://github.com/TryCaspian/caspian-sdk) — an open-source SDK (Python + TypeScript, Apache-2.0) that gives an AI agent one messaging identity across Slack, Discord, Telegram, Instagram, email, and X behind a single `on_message` handler. Added to Tools alongside the other agent-infrastructure entries, matching the existing format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Dt6LAQdpojPr3Kvbi2V8m