### PR TITLE
Add engRAM to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ Exploring endless possibilities with open-source agent social simulation.
 - [DOS (dos-kernel)](https://github.com/anthony-chaudhary/dos-kernel) - Trust kernel for AI agent fleets: verifies an agent's "done" claim from git evidence (never self-report), arbitrates file collisions between concurrent agents, and refuses with structured machine-checkable reasons. CLI + MCP server + Claude Code plugin. ![GitHub Repo stars](https://img.shields.io/github/stars/anthony-chaudhary/dos-kernel?style=social)
 - [Cynative](https://github.com/cynative/cynative) - Agentic security CLI that runs code in a built-in sandbox to research cloud, code and runtime. Read-only by construction. ![GitHub Repo stars](https://img.shields.io/github/stars/cynative/cynative?style=social)
 - [Nika](https://github.com/supernovae-st/nika) - Intent-as-code workflow engine for AI agents: reviewable YAML DAGs statically checked (schema, permits, honest cost floor) before any token is spent, tamper-evident traces after. Single Rust binary. ![GitHub Repo stars](https://img.shields.io/github/stars/supernovae-st/nika?style=social)
+- [engRAM](https://github.com/MaxFreedomPollard/engRAM) - Local-first, offline encrypted vector memory for AI agents over MCP or CLI, with AEAD-encrypted-at-rest records and embeddings, RAM-resident exact vector search, per-record crypto-shred deletion, and a hash-chained audit log. MIT, Python. ![GitHub Repo stars](https://img.shields.io/github/stars/MaxFreedomPollard/engRAM?style=social)
 
 ## Frameworks
 


### PR DESCRIPTION
Adds **engRAM** to the Tools section.

engRAM is local-first, offline encrypted vector memory for AI agents, usable over MCP or from the CLI. Records and embeddings are AEAD-encrypted at rest; it does RAM-resident exact vector search, per-record crypto-shred deletion, and keeps a hash-chained audit log. MIT, Python.

Repo: https://github.com/MaxFreedomPollard/engRAM