### PR TITLE
Add whatbroke to Benchmark/Evaluator

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,7 @@ Benchmarks to evaluate LLM-as-Agent across a variety of environments.
 - [Cross-Agent Review Queue 2026](https://huggingface.co/datasets/neogenesislab/cross-agent-review-queue-2026) - Open dataset of cross-agent collaboration review transcripts (Codex <-> Claude reviewer / architect / implementer handoffs) with structured fields for owner-goal restatement, review lens, and result code (NEW_SIGNAL / NO_NEW_SIGNAL); useful for multi-agent handoff and review-quality evaluation.
 - [Future AGI](https://github.com/future-agi/future-agi) - Open-source platform to simulate, evaluate, trace, guardrail, and optimize LLM and AI agent apps, with 70+ eval metrics and OpenTelemetry-native tracing across 50+ frameworks. ![GitHub Repo stars](https://img.shields.io/github/stars/future-agi/future-agi?style=social)
 - [CIAgent](https://github.com/suniel12/ciagent) - Pytest-native regression testing for AI agents — golden-trace diffing, cost guardrails, multi-run stability scoring with flip attribution, LLM-judge auditing, and one-command import of production traces (OTel/Langfuse/LangSmith) into CI tests. ![GitHub Repo stars](https://img.shields.io/github/stars/suniel12/ciagent?style=social)
+- [whatbroke](https://github.com/arthi-arumugam-git/whatbroke) - CLI that diffs two runs of an AI agent to show changes in tool calls, arguments, cost, latency, and outcomes, with multi-sample flake detection to demote pre-existing flakiness. ![GitHub Repo stars](https://img.shields.io/github/stars/arthi-arumugam-git/whatbroke?style=social)
 
 
 ## Platforms/API


### PR DESCRIPTION
Adds whatbroke, a CLI that diffs an AI agent's behavior between two runs: tool calls, arguments, cost, latency, and outcome changes. It also runs multiple samples to separate real regressions from pre-existing flakiness. MIT licensed, TypeScript, on npm as whatbroke-cli. Placed in the Benchmark/Evaluator section following the entry format from CONTRIBUTING. Happy to adjust wording or placement if needed.