### PR TITLE
Add Cog Depot to Platforms/API

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,7 @@ Able to connect LLM with the real world.
 - [elisym](https://github.com/elisymlabs/elisym) - Open-source TypeScript implementation of a Nostr-based protocol (NIP-89/NIP-90) for AI agent discovery and job exchange, with Solana payment settlement. ![GitHub Repo stars](https://img.shields.io/github/stars/elisymlabs/elisym?style=social)
 - [openma](https://github.com/open-ma/open-managed-agents) - Self-hosted, open-source implementation of Anthropic's Managed Agents API. Wire-compatible with the official SDKs. Runs on Cloudflare Workers + Durable Objects or Node. Apache 2.0. ![GitHub Repo stars](https://img.shields.io/github/stars/open-ma/open-managed-agents?style=social)
 - [Enclave](https://github.com/wartzar-bee/enclave) - Security-first, brain-agnostic self-hosted runtime for autonomous AI agents. Each agent runs in a hardened container (`--cap-drop=ALL --security-opt=no-new-privileges`, no inbound ports, report-only egress policy, AES-256 vault-encrypted secrets) and is brain-agnostic via one env var (`BRAIN=claude | api | local`). Apache-2.0. ![GitHub Repo stars](https://img.shields.io/github/stars/wartzar-bee/enclave?style=social)
+- [Cog Depot](https://cogdepot.com) - Hosted A2A-native peer-to-peer marketplace where buyer and seller agents discover listings, negotiate deals, and settle in BTC/stablecoins. Public Agent Card plus JSON-RPC `message/send`, so any A2A client can transact.
 
 ## Related
 


### PR DESCRIPTION
Adds **Cog Depot** to the *Platforms/API* section (appended at the bottom, per CONTRIBUTING).

Cog Depot is a hosted, A2A-native peer-to-peer marketplace: buyer and seller agents discover listings, negotiate deals, and settle in BTC/stablecoins. It publishes an Agent Card at https://api.cogdepot.com/.well-known/agent-card.json and speaks JSON-RPC `message/send`, so any A2A client can transact with it.

Disclosure: it is a hosted service, not an open-source repo, so the entry has no stars badge - same shape as the existing BidClub, Crewship, and Taskade Genesis entries in this section. Closest neighbours already listed are Pinchwork and SwarmTrade (agent-to-agent marketplaces). I work on Cog Depot.

Docs: https://cogdepot.com/docs