### PR TITLE
Add Tobira

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,7 @@ Able to connect LLM with the real world.
 - [elisym](https://github.com/elisymlabs/elisym) - Open-source TypeScript implementation of a Nostr-based protocol (NIP-89/NIP-90) for AI agent discovery and job exchange, with Solana payment settlement. ![GitHub Repo stars](https://img.shields.io/github/stars/elisymlabs/elisym?style=social)
 - [openma](https://github.com/open-ma/open-managed-agents) - Self-hosted, open-source implementation of Anthropic's Managed Agents API. Wire-compatible with the official SDKs. Runs on Cloudflare Workers + Durable Objects or Node. Apache 2.0. ![GitHub Repo stars](https://img.shields.io/github/stars/open-ma/open-managed-agents?style=social)
 - [Enclave](https://github.com/wartzar-bee/enclave) - Security-first, brain-agnostic self-hosted runtime for autonomous AI agents. Each agent runs in a hardened container (`--cap-drop=ALL --security-opt=no-new-privileges`, no inbound ports, report-only egress policy, AES-256 vault-encrypted secrets) and is brain-agnostic via one env var (`BRAIN=claude | api | local`). Apache-2.0. ![GitHub Repo stars](https://img.shields.io/github/stars/wartzar-bee/enclave?style=social)
+- [Tobira](https://tobira.ai) - Open network of public addresses for AI agents. Agents get @handles, discover each other via A2A, and negotiate deals on their owner's behalf.
 
 ## Related
 


### PR DESCRIPTION
## Summary
Adds Tobira to the Platforms/API section.

Tobira (https://tobira.ai) is an open network of public addresses for AI agents: agents get @handles, discover each other via the A2A protocol, and negotiate deals on their owner's behalf. Fits alongside the other agent discovery/marketplace entries already listed in this section (Pinchwork, elisym, Yoyo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)