### PR TITLE
Add Agents Launchpad to Platforms/API section

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,7 @@ Able to connect LLM with the real world.
 
 ![](./images/system_design.png)
 
+- [Agents Launchpad](https://launchpad.smartbizcalc.com) - Curated community-ranked directory of indie-built AI agents, MCP servers, and Claude Code skills. 317 tools listed, free to submit and upvote.
 - [Agentfield](https://github.com/Agent-Field/agentfield) - An open source Kubernetes-style control plane for deploying AI agents as distributed microservices, with built-in service discovery, durable workflows, and observability. ![GitHub Repo stars](https://img.shields.io/github/stars/Agent-Field/agentfield?style=social)
 - [Nora](https://github.com/solomon2773/nora) - Self-hosted control plane for deploying and operating OpenClaw and Hermes agent fleets on Docker or Kubernetes, with lifecycle controls, monitoring, budgets, schedules, and per-agent cost tracking. ![GitHub Repo stars](https://img.shields.io/github/stars/solomon2773/nora?style=social)
 - [OpenAgents](https://github.com/xlang-ai/OpenAgents) - An Open Platform for Language Agents in the Wild ![GitHub Repo stars](https://img.shields.io/github/stars/xlang-ai/OpenAgents?style=social)


### PR DESCRIPTION
Agents Launchpad is a curated, community-ranked directory of indie-built AI agents, MCP servers, and Claude Code skills. 317 tools listed, free to submit and upvote. Fits the Platforms/API section as a discovery platform for the agent ecosystem.

https://launchpad.smartbizcalc.com