### PR TITLE
Add Atomic Agent to Autonomous Agent Task Solver Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Open-source Large Language Model (LLM) driven autonomous agent that can automati
 - [CompozyOS](https://github.com/compozy/compozy) - Self-hosted agent operating system: 26 providers, background loops and schedules, shared memory, approvals and an agent-to-agent network.
 - [BitFun](https://github.com/GCWing/BitFun) - Open-source coding agent with a Rust runtime, desktop and CLI interfaces, self-hosted multi-device control, and stateful Mini Apps. ![GitHub Repo stars](https://img.shields.io/github/stars/GCWing/BitFun?style=social)
 - [Ouroboros](https://github.com/razzant/ouroboros) - Self-hosted general-purpose agent with durable identity and memory, reviewed self-modification, specialist subagent swarms, and desktop or headless operation. ![GitHub Repo stars](https://img.shields.io/github/stars/razzant/ouroboros?style=social)
+- [Atomic Agent](https://github.com/AtomicBot-ai/atomic-agent) - Local-first CLI and TUI coding agent that runs open-weight models entirely on your machine via a llama.cpp fork. 56 tools (browser, filesystem, git, memory, vision), MCP support, and a 5-layer local memory. macOS/Linux/Windows, MIT. ![GitHub Repo stars](https://img.shields.io/github/stars/AtomicBot-ai/atomic-agent?style=social)
 
 ### Multi-Agent Task Solver Projects
 


### PR DESCRIPTION
## Summary

Adds Atomic Agent to Applications / Autonomous Agent Task Solver Projects. It is a local-first CLI and TUI coding agent that runs open-weight models entirely on your machine via a llama.cpp fork. MIT licensed, actively maintained.

## Type of change

- [x] Add new resource entry
- [ ] Update existing entry
- [ ] Remove outdated/invalid entry
- [ ] Formatting/typo only

## Target section

Specify where this change belongs in `README.md`:

- [x] Applications / Autonomous Agent Task Solver Projects
- [ ] Applications / Multi-Agent Task Solver Projects
- [ ] Applications / Agent Society Simulation
- [ ] Applications / Advanced Components
- [ ] Applications / Tools
- [ ] Frameworks
- [ ] Benchmark/Evaluator
- [ ] Platforms/API
- [ ] Related / Survey
- [ ] Related / Paper-List Repo
- [ ] Related / Blog
- [ ] Reference Repo

## Quality checks (required)

- [x] I searched `README.md` and confirmed this is not a duplicate.
- [x] The submission is relevant to the AI agent ecosystem.
- [x] The description is neutral and evidence-based (not promotional).
- [x] I removed unverifiable claims (e.g., "best", "first") or provided clear evidence.
- [x] If this is open source, license information is clear.
- [x] The linked project/resource has usable documentation (README/docs).
- [x] If this project depends on a paid or closed hosted service, the OSS artifact still has clear standalone value and this PR does not function mainly as service promotion.

## Proposed entry line

Paste the exact line added/updated:

```md
- [Atomic Agent](https://github.com/AtomicBot-ai/atomic-agent) - Local-first CLI and TUI coding agent that runs open-weight models entirely on your machine via a llama.cpp fork. 56 tools (browser, filesystem, git, memory, vision), MCP support, and a 5-layer local memory. macOS/Linux/Windows, MIT. ![GitHub Repo stars](https://img.shields.io/github/stars/AtomicBot-ai/atomic-agent?style=social)
```

## Evidence (optional but recommended)

- Repository: https://github.com/AtomicBot-ai/atomic-agent (MIT license, active)
- Documentation: https://atomicagent.io/docs
- Website: https://atomicagent.io

Atomic Agent is not a wrapper over a hosted service. It runs open-weight models locally through a bundled llama.cpp fork, so the agent loop, the 56 tools, and the 5-layer memory all work on the user's own machine without any hosted backend. Everything meaningful in the repo is usable standalone.
