### PR TITLE
Add Lians to agent tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Exploring endless possibilities with open-source agent social simulation.
 
 ### Tools
 
+- [Lians](https://github.com/Lians-ai/Lians) - Local-first memory layer for AI agents with MCP, Python, and TypeScript interfaces; SQLite-backed recall, user-controlled inspection/correction/deletion, and point-in-time memory receipts. ![GitHub Repo stars](https://img.shields.io/github/stars/Lians-ai/Lians?style=social)
 - [Perseus](https://github.com/tcconnally/perseus) - Live workspace context engine for AI agents. Renders AGENTS.md at session start. Plug-in for Claude Code, Codex, Hermes.
 - [EGC](https://github.com/Fmarzochi/EGC) - Cross-session persistent memory layer for AI coding agents (Claude Code, Cursor, Gemini CLI, Codex, Windsurf, Amp, Kiro, and more). SQLite-backed. ![GitHub Repo stars](https://img.shields.io/github/stars/Fmarzochi/EGC?style=social)
 


### PR DESCRIPTION
## Summary

Adds Lians as one neutral entry in **Applications / Tools**.

## Type of change

- [x] Add new resource entry
- [ ] Update existing entry
- [ ] Remove outdated/invalid entry
- [ ] Formatting/typo only

## Target section

- [x] Applications / Tools

## Quality checks (required)

- [x] I searched `README.md` and confirmed this is not a duplicate.
- [x] The submission is relevant to the AI agent ecosystem.
- [x] The description is neutral and evidence-based (not promotional).
- [x] I removed unverifiable claims or provided clear evidence.
- [x] The Apache-2.0 license is clear in the repository.
- [x] The linked project has install and usage documentation.
- [x] Local SQLite and MCP/SDK functionality is independently usable without a paid or closed service.

## Proposed entry line

```md
- [Lians](https://github.com/Lians-ai/Lians) - Local-first memory layer for AI agents with MCP, Python, and TypeScript interfaces; SQLite-backed recall, user-controlled inspection/correction/deletion, and point-in-time memory receipts. ![GitHub Repo stars](https://img.shields.io/github/stars/Lians-ai/Lians?style=social)
```

## Evidence

- Apache-2.0 license: https://github.com/Lians-ai/Lians/blob/master/LICENSE
- Local MCP and SDK setup: https://github.com/Lians-ai/Lians#readme
- The repository contains the local SQLite implementation and does not require a hosted Lians service for this functionality.

## Disclosure

I am affiliated with Lians. This contribution was drafted with AI assistance and manually checked against this repository's contribution rules and the linked source.