### PR TITLE
Add DSH Studio to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,8 @@ Able to connect LLM with the real world.
 - [openma](https://github.com/open-ma/open-managed-agents) - Self-hosted, open-source implementation of Anthropic's Managed Agents API. Wire-compatible with the official SDKs. Runs on Cloudflare Workers + Durable Objects or Node. Apache 2.0. ![GitHub Repo stars](https://img.shields.io/github/stars/open-ma/open-managed-agents?style=social)
 - [Enclave](https://github.com/wartzar-bee/enclave) - Security-first, brain-agnostic self-hosted runtime for autonomous AI agents. Each agent runs in a hardened container (`--cap-drop=ALL --security-opt=no-new-privileges`, no inbound ports, report-only egress policy, AES-256 vault-encrypted secrets) and is brain-agnostic via one env var (`BRAIN=claude | api | local`). Apache-2.0. ![GitHub Repo stars](https://img.shields.io/github/stars/wartzar-bee/enclave?style=social)
 
+- [DSH Studio](https://github.com/Moresyl/dsh-studio) - Cross-platform desktop shell that installs, supervises, and hosts DeepSeek Harness locally. ![GitHub Repo stars](https://img.shields.io/github/stars/Moresyl/dsh-studio?style=social)
+
 ## Related
 
 ### Survey


### PR DESCRIPTION
## Summary

Adds DSH Studio, an MIT-licensed desktop shell for installing, supervising, and hosting DeepSeek Harness locally.

## Type of change

- [x] Add new resource entry
- [ ] Update existing entry
- [ ] Remove outdated/invalid entry
- [ ] Formatting/typo only

## Target section

- [ ] Applications / Autonomous Agent Task Solver Projects
- [ ] Applications / Multi-Agent Task Solver Projects
- [ ] Applications / Agent Society Simulation
- [ ] Applications / Advanced Components
- [x] Applications / Tools
- [ ] Frameworks
- [ ] Benchmark/Evaluator
- [ ] Platforms/API
- [ ] Related / Survey
- [ ] Related / Paper-List Repo
- [ ] Related / Blog
- [ ] Reference Repo

## Quality checks (required)

- [x] I searched `README.md` and confirmed this is not a duplicate.
- [x] The submission is relevant to the AI agent ecosystem.
- [x] The description is neutral and evidence-based (not promotional).
- [x] I removed unverifiable claims (e.g., "best", "first") or provided clear evidence.
- [x] If this is open source, license information is clear.
- [x] The linked project/resource has usable documentation (README/docs).
- [x] If this project depends on a paid or closed hosted service, the OSS artifact still has clear standalone value and this PR does not function mainly as service promotion.

## Proposed entry line

```md
- [DSH Studio](https://github.com/Moresyl/dsh-studio) - Cross-platform desktop shell that installs, supervises, and hosts DeepSeek Harness locally. ![GitHub Repo stars](https://img.shields.io/github/stars/Moresyl/dsh-studio?style=social)
```

## Evidence

- Documentation and install instructions: https://github.com/Moresyl/dsh-studio#readme
- MIT license: https://github.com/Moresyl/dsh-studio/blob/main/LICENSE
- Cross-platform release artifacts: https://github.com/Moresyl/dsh-studio/releases

The application runs locally and remains useful without a paid hosted service: it installs the upstream harness into a private prefix, supervises its local process and health, and hosts the unmodified local UI.