### PR TITLE
Add MCP Lens to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ Exploring endless possibilities with open-source agent social simulation.
 - [Nika](https://github.com/supernovae-st/nika) - Intent-as-code workflow engine for AI agents: reviewable YAML DAGs statically checked (schema, permits, honest cost floor) before any token is spent, tamper-evident traces after. Single Rust binary. ![GitHub Repo stars](https://img.shields.io/github/stars/supernovae-st/nika?style=social)
 - [engRAM](https://github.com/MaxFreedomPollard/engRAM) - Local-first, offline encrypted vector memory for AI agents over MCP or CLI, with AEAD-encrypted-at-rest records and embeddings, RAM-resident exact vector search, per-record crypto-shred deletion, and a hash-chained audit log. MIT, Python. ![GitHub Repo stars](https://img.shields.io/github/stars/MaxFreedomPollard/engRAM?style=social)
 - [Caspian](https://github.com/TryCaspian/caspian-sdk) - One messaging identity for an AI agent across Slack, Discord, Telegram, Instagram, email, and X — a single `on_message` handler with threading, webhook verification, and platform quirks handled. Python + TypeScript SDK. ![GitHub Repo stars](https://img.shields.io/github/stars/TryCaspian/caspian-sdk?style=social)
+- [MCP Lens](https://github.com/labmimors/dsh-mcp-lens) - Open-source DeepSeek Harness plugin that discovers MCP tools through search and invokes selected tools with their exact input schemas. ![GitHub Repo stars](https://img.shields.io/github/stars/labmimors/dsh-mcp-lens?style=social)
 
 ## Frameworks
 


### PR DESCRIPTION
## Summary

- Add MCP Lens to the Tools section with a neutral one-line description.

## Fit and disclosure

MCP Lens is an MIT-licensed DeepSeek Harness plugin for MCP tool discovery and explicit exact-schema invocation. It is locally usable open-source software and does not require a hosted service.

Disclosure: I maintain `dsh-mcp-lens` under the `labmimors` account.

## Checks

- Searched the README and the current open/closed PR inventory for duplicates.
- Verified the public repository includes installation and usage documentation plus an MIT license.
- Kept the diff to one README insertion and ran `git diff --check`.
