### PR TITLE
Add ClawMetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ Exploring endless possibilities with open-source agent social simulation.
 - [Nika](https://github.com/supernovae-st/nika) - Intent-as-code workflow engine for AI agents: reviewable YAML DAGs statically checked (schema, permits, honest cost floor) before any token is spent, tamper-evident traces after. Single Rust binary. ![GitHub Repo stars](https://img.shields.io/github/stars/supernovae-st/nika?style=social)
 - [engRAM](https://github.com/MaxFreedomPollard/engRAM) - Local-first, offline encrypted vector memory for AI agents over MCP or CLI, with AEAD-encrypted-at-rest records and embeddings, RAM-resident exact vector search, per-record crypto-shred deletion, and a hash-chained audit log. MIT, Python. ![GitHub Repo stars](https://img.shields.io/github/stars/MaxFreedomPollard/engRAM?style=social)
 - [Caspian](https://github.com/TryCaspian/caspian-sdk) - One messaging identity for an AI agent across Slack, Discord, Telegram, Instagram, email, and X — a single `on_message` handler with threading, webhook verification, and platform quirks handled. Python + TypeScript SDK. ![GitHub Repo stars](https://img.shields.io/github/stars/TryCaspian/caspian-sdk?style=social)
+- [ClawMetry](https://github.com/vivekchand/clawmetry) - Zero-config observability dashboard for AI agent runtimes. Sessions, token costs, tool calls, live traces. ![GitHub Repo stars](https://img.shields.io/github/stars/vivekchand/clawmetry?style=social)
 
 ## Frameworks
 


### PR DESCRIPTION
Adds [ClawMetry](https://github.com/vivekchand/clawmetry) to the Tools section, matching the existing entry format with the stars badge.

ClawMetry is a zero-config observability dashboard for AI agent runtimes: sessions, token costs, tool calls, and live traces. Open source, installs with pip install clawmetry.