### PR TITLE
Add SandBase Harness agent runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ Exploring endless possibilities with open-source agent social simulation.
 ### Tools
 
 - [DSH Studio](https://github.com/Moresyl/dsh-studio) - Cross-platform desktop host for installing, running, health-checking, and supervising DeepSeek Harness locally. ![GitHub Repo stars](https://img.shields.io/github/stars/Moresyl/dsh-studio?style=social)
+- [SandBase Harness](https://github.com/sandbaseai/sandbase-harness) - Local-first TypeScript agent runtime with persistent sessions, per-session sandboxes, MCP toolsets, approvals, credential vaults, audit, and replay. ![GitHub Repo stars](https://img.shields.io/github/stars/sandbaseai/sandbase-harness?style=social)
 - [Lians](https://github.com/Lians-ai/Lians) - Local-first memory layer for AI agents with MCP, Python, and TypeScript interfaces; SQLite-backed recall, user-controlled inspection/correction/deletion, and point-in-time memory receipts. ![GitHub Repo stars](https://img.shields.io/github/stars/Lians-ai/Lians?style=social)
 - [Perseus](https://github.com/tcconnally/perseus) - Live workspace context engine for AI agents. Renders AGENTS.md at session start. Plug-in for Claude Code, Codex, Hermes.
 - [EGC](https://github.com/Fmarzochi/EGC) - Cross-session persistent memory layer for AI coding agents (Claude Code, Cursor, Gemini CLI, Codex, Windsurf, Amp, Kiro, and more). SQLite-backed. ![GitHub Repo stars](https://img.shields.io/github/stars/Fmarzochi/EGC?style=social)


### PR DESCRIPTION
## Summary

Add [SandBase Harness](https://github.com/sandbaseai/sandbase-harness) to **Applications → Tools**, next to the existing DSH Studio entry.

The entry is a neutral, source-verifiable description of the independently usable Apache-2.0 runtime: persistent sessions, per-session sandbox backends, MCP toolsets, approvals, credential vaults, audit, and replay. It does not depend on a paid hosted service.

## Checks

- Confirmed no existing README entry or prior SandBase PR
- Standard Apache-2.0 license is visible in repository metadata
- `git diff --check` passes

## Disclosure

I contribute to the SandBase project.