### PR TITLE
Add Agent Swarm

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Open-source Large Language Model (LLM) driven autonomous agent that can automati
 - [Sudarshan](https://github.com/Suraj1235/sudarshan-superharness) - Durable build harness that drives an LLM from an idea, PRD, or spec to software gated on passing verification commands, with resumable checkpointed state; provider-neutral across OpenAI-compatible, Anthropic, Gemini, local, and command-bridge backends. ![GitHub Repo stars](https://img.shields.io/github/stars/Suraj1235/sudarshan-superharness?style=social)
 - [SARA](https://github.com/Alessandro114/sara) - Self-hosted WhatsApp AI agent (AGPL-3.0) with 20 industry verticals, function calling (30+ tools), RAG via pgvector, and multi-provider LLM failover (Groq → Cerebras → SambaNova → Mistral). ![GitHub Repo stars](https://img.shields.io/github/stars/Alessandro114/sara?style=social)
 - [Atomic Agent](https://github.com/AtomicBot-ai/atomic-agent) - Local-first CLI and TUI coding agent that runs open-weight models entirely on your machine via a llama.cpp fork. 56 tools (browser, filesystem, git, memory, vision), MCP support, and a 5-layer local memory. macOS/Linux/Windows, MIT. ![GitHub Repo stars](https://img.shields.io/github/stars/AtomicBot-ai/atomic-agent?style=social)
+- [Agent Swarm](https://github.com/desplega-ai/agent-swarm) - Self-hosted multi-agent system where a lead agent delegates tasks to specialized workers with shared memory, tools, schedules, and review gates. ![GitHub Repo stars](https://img.shields.io/github/stars/desplega-ai/agent-swarm?style=social)
 
 ### Multi-Agent Task Solver Projects
 


### PR DESCRIPTION
## Summary

Describe what this PR adds/updates in 1-3 lines.

## Type of change

- [X] Add new resource entry
- [ ] Update existing entry
- [ ] Remove outdated/invalid entry
- [ ] Formatting/typo only

## Target section

Specify where this change belongs in `README.md`:

- [X] Applications / Autonomous Agent Task Solver Projects
- [ ] Applications / Multi-Agent Task Solver Projects
- [ ] Applications / Agent Society Simulation
- [ ] Applications / Advanced Components
- [ ] Applications / Tools
- [ ] Frameworks
- [ ] Benchmark/Evaluator
- [ ] Platforms/API
- [ ] Related / Survey
- [ ] Related / Paper-List Repo
- [ ] Related / Blog
- [ ] Reference Repo

## Quality checks (required)

- [X] I searched `README.md` and confirmed this is not a duplicate.
- [X] The submission is relevant to the AI agent ecosystem.
- [X] The description is neutral and evidence-based (not promotional).
- [X] I removed unverifiable claims (e.g., "best", "first") or provided clear evidence.
- [X] If this is open source, license information is clear.
- [X] The linked project/resource has usable documentation (README/docs).
- [X] If this project depends on a paid or closed hosted service, the OSS artifact still has clear standalone value and this PR does not function mainly as service promotion.

## Proposed entry line

Paste the exact line added/updated:

```md
- [Agent Swarm](https://github.com/desplega-ai/agent-swarm) - Self-hosted multi-agent system where a lead agent delegates tasks to specialized workers with shared memory, tools, schedules, and review gates. ![GitHub Repo stars](https://img.shields.io/github/stars/desplega-ai/agent-swarm?style=social)
```

## Evidence (optional but recommended)

It's MIT licensed, and here's our latest open case study with a company using it in production: https://www.agent-swarm.dev/case-studies/capchase

We have a cloud offering, but we are not promoting in this PR (only in the landing and a small link in the readme). Main goal is to self-host (k8s, docker compose).
