### PR TITLE
Add inspeximus to Advanced Components

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ Exploring endless possibilities with open-source agent social simulation.
 ### Advanced Components
 - [Cache-to-Cache](https://github.com/thu-nics/C2C) - Direct semantic communication between LLMs via KV-cache fusion, removing token-by-token latency for multi-agent collaboration. ![GitHub Repo stars](https://img.shields.io/github/stars/thu-nics/C2C?style=social)
 - [CoWorker Protocol](https://github.com/ZiwayZhao/agent-coworker) - P2P agent collaboration over XMTP with schema-based skill invocation, E2E encryption, and revocable trust. Agents share capabilities without exposing code. ![GitHub Repo stars](https://img.shields.io/github/stars/ZiwayZhao/agent-coworker?style=social)
+- [inspeximus](https://github.com/DanceNitra/inspeximus) - Memory component for long-running agents: a correction retires the old value by key, revert() undoes the correction from a plain instruction, and every write leaves a verifiable receipt. Deterministic, no model in the loop, one zero-dependency file.
 
 ### Tools
 


### PR DESCRIPTION
Adding inspeximus under Advanced Components, in the same format as the entries beside it.

It is the memory layer for the case where a stored fact turns out to be wrong. `remember(key=...)` retires the previous value for that key rather than adding a second one that competes with it in retrieval, `revert(key)` restores it on command, and `history(key)` shows what retired what. No model arbitrates, so identical inputs produce an identical stored state.

Base package is one Python file with zero dependencies. An MCP server and framework adapters are opt-in extras.

Measured, each system in its own native configuration: after a correction, recall returns the new value and not the old one in 20/20 trials here against 1/20 for mem0, with 0 model calls against 60. Method and the cells where it does not win: https://github.com/DanceNitra/inspeximus/blob/main/probes/INTEGRITY_BENCHMARK.md

Thanks for the list; the Benchmark/Evaluator section sent me somewhere useful last month.
