### PR TITLE
Add DSH Meme Hub to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Exploring endless possibilities with open-source agent social simulation.
 ### Tools
 
 - [DSH Studio](https://github.com/Moresyl/dsh-studio) - Cross-platform desktop host for installing, running, health-checking, and supervising DeepSeek Harness locally. ![GitHub Repo stars](https://img.shields.io/github/stars/Moresyl/dsh-studio?style=social)
+- [DSH Meme Hub](https://github.com/the-beating-light-of-the-nail/dsh-meme-hub) - Curated navigation site for the DeepSeek Harness community: 87 plugins across 13 categories, daily star leaderboards, a dedicated Meme Zone for fun plugins, bilingual (EN/ZH), open submissions. ![GitHub Repo stars](https://img.shields.io/github/stars/the-beating-light-of-the-nail/dsh-meme-hub?style=social)
 - [Lians](https://github.com/Lians-ai/Lians) - Local-first memory layer for AI agents with MCP, Python, and TypeScript interfaces; SQLite-backed recall, user-controlled inspection/correction/deletion, and point-in-time memory receipts. ![GitHub Repo stars](https://img.shields.io/github/stars/Lians-ai/Lians?style=social)
 - [Perseus](https://github.com/tcconnally/perseus) - Live workspace context engine for AI agents. Renders AGENTS.md at session start. Plug-in for Claude Code, Codex, Hermes.
 - [EGC](https://github.com/Fmarzochi/EGC) - Cross-session persistent memory layer for AI coding agents (Claude Code, Cursor, Gemini CLI, Codex, Windsurf, Amp, Kiro, and more). SQLite-backed. ![GitHub Repo stars](https://img.shields.io/github/stars/Fmarzochi/EGC?style=social)


### PR DESCRIPTION
Adds [DSH Meme Hub](https://github.com/the-beating-light-of-the-nail/dsh-meme-hub) to the **Tools** section, right after DSH Studio (same DeepSeek Harness ecosystem).

- Curated navigation site for DSH community plugins: 87 plugins, 13 categories
- Daily star leaderboards + a dedicated Meme Zone for fun plugins
- Bilingual (EN/ZH), open submissions
- Live site: https://dsh-meme-hub.cdqyfdbymn.me/

Thanks!