### PR TITLE
Add sofagent (audit & governance harness) to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ Exploring endless possibilities with open-source agent social simulation.
 - [Caspian](https://github.com/TryCaspian/caspian-sdk) - One messaging identity for an AI agent across Slack, Discord, Telegram, Instagram, email, and X — a single `on_message` handler with threading, webhook verification, and platform quirks handled. Python + TypeScript SDK. ![GitHub Repo stars](https://img.shields.io/github/stars/TryCaspian/caspian-sdk?style=social)
 - [MCP Lens](https://github.com/labmimors/dsh-mcp-lens) - Open-source DeepSeek Harness plugin that discovers MCP tools through search and invokes selected tools with their exact input schemas. ![GitHub Repo stars](https://img.shields.io/github/stars/labmimors/dsh-mcp-lens?style=social)
 - [Agent Coordinator](https://github.com/alanhoff/agent-coordinator) - Codex skill that records complex tasks as revisioned work graphs, rejects overlapping write scopes, reconciles uncertain work before retry, and reruns completion checks. ![GitHub Repo stars](https://img.shields.io/github/stars/alanhoff/agent-coordinator?style=social)
+- [sofagent](https://github.com/KongFangXun/sofagent) - Audit-first governance harness for AI coding agents: 24 rules enforced at commit time via git hooks, HMAC-chained audit log, snapshot rollback. MIT. ![GitHub Repo stars](https://img.shields.io/github/stars/KongFangXun/sofagent?style=social)
 
 ## Frameworks
 


### PR DESCRIPTION
Adds [KongFangXun/sofagent](https://github.com/KongFangXun/sofagent) to the **Tools** section (at the end, after Agent Coordinator).

**Disclosure: this is a self-submission.** I am the author and maintainer of sofagent.

sofagent is an audit-first governance harness for AI coding agents: 24 audit rules enforced at commit time via git hooks (secret leakage, out-of-scope file changes, destructive ops), HMAC-chained tamper-evident audit log, and snapshot rollback. MIT-licensed, TypeScript, works with any git repository. Installable as a CLI (`npx @sofagent/audit`), skill, or MCP server.

On the quality bar: standard MIT OSS license, no paid backend dependency, works fully offline/local.

Related listings: [awesome-dsh-plugin #4101 (merged)](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/pull/4101) · [agentrust-io/awesome-ai-governance #89 (merged)](https://github.com/agentrust-io/awesome-ai-governance/pull/89) · [mahseema/awesome-ai-tools #2078 (open)](https://github.com/mahseema/awesome-ai-tools/pull/2078)

Single-line change to README.md only.

