### PR TITLE
Add ossbeat blog to resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,6 +328,7 @@ Able to connect LLM with the real world.
 
 ### Blog
 
+- [ossbeat](https://ossbeat.com) - Weekly write-ups tracking release notes and trends across open-source AI coding agent tooling (MCP, coding agent harnesses, agent-to-agent protocols).
 - [LLM Powered Autonomous Agents](https://lilianweng.github.io/posts/2023-06-23-agent/) - Amazing blog by Lilian Weng (OpenAI), Jun 23, 2023.
 - [从第一性原理看大模型Agent技术](https://mp.weixin.qq.com/s/PL-QjlvVugUfmRD4g0P-qQ)
 - [基于大语言模型的AI Agents](https://www.breezedeus.com/article/ai-agent-part3)


### PR DESCRIPTION
Added a new blog resource tracking open-source AI coding agent tooling.

## Summary
Adds ossbeat (https://ossbeat.com) to the Blog section — a weekly blog tracking release notes and trends across open-source AI coding agent tooling (MCP, coding agent harnesses, agent-to-agent protocols). Currently 18 published posts.

## Type of change

- [x] Add new resource entry
- [ ] Update existing entry
- [ ] Remove outdated/invalid entry
- [ ] Formatting/typo only

## Target section

Specify where this change belongs in `README.md`:

- [ ] Applications / Autonomous Agent Task Solver Projects
- [ ] Applications / Multi-Agent Task Solver Projects
- [ ] Applications / Agent Society Simulation
- [ ] Applications / Advanced Components
- [ ] Applications / Tools
- [ ] Frameworks
- [ ] Benchmark/Evaluator
- [ ] Platforms/API
- [ ] Related / Survey
- [ ] Related / Paper-List Repo
- [x] Related / Blog
- [ ] Reference Repo

## Quality checks (required)

- [x] I searched `README.md` and confirmed this is not a duplicate.
- [x] The submission is relevant to the AI agent ecosystem.
- [x] The description is neutral and evidence-based (not promotional).
- [x] I removed unverifiable claims (e.g., "best", "first") or provided clear evidence.
- [x] If this is open source, license information is clear.
- [x] The linked project/resource has usable documentation (README/docs).
- [x] If this project depends on a paid or closed hosted service, the OSS artifact still has clear standalone value and this PR does not function mainly as service promotion.

## Proposed entry line

Paste the exact line added/updated:

```md
- [ossbeat](https://ossbeat.com) - Weekly write-ups tracking release notes and trends across open-source AI coding agent tooling (MCP, coding agent harnesses, agent-to-agent protocols).
```

## Evidence (optional but recommended)
Site itself demonstrates the content/quality: https://ossbeat.com

Not applicable — ossbeat is a free, publicly accessible blog with no paid or closed backend dependency.
