### PR TITLE
Add Lumbox to Platforms/API

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,7 @@ Able to connect LLM with the real world.
 - [openma](https://github.com/open-ma/open-managed-agents) - Self-hosted, open-source implementation of Anthropic's Managed Agents API. Wire-compatible with the official SDKs. Runs on Cloudflare Workers + Durable Objects or Node. Apache 2.0. ![GitHub Repo stars](https://img.shields.io/github/stars/open-ma/open-managed-agents?style=social)
 - [Enclave](https://github.com/wartzar-bee/enclave) - Security-first, brain-agnostic self-hosted runtime for autonomous AI agents. Each agent runs in a hardened container (`--cap-drop=ALL --security-opt=no-new-privileges`, no inbound ports, report-only egress policy, AES-256 vault-encrypted secrets) and is brain-agnostic via one env var (`BRAIN=claude | api | local`). Apache-2.0. ![GitHub Repo stars](https://img.shields.io/github/stars/wartzar-bee/enclave?style=social)
 - [Bifrost](https://github.com/maximhq/bifrost) - Open-source Go AI gateway with provider routing, automatic failover, load balancing, observability, and MCP support. ![GitHub Repo stars](https://img.shields.io/github/stars/maximhq/bifrost?style=social)
+- [Lumbox](https://lumbox.co) - Email infrastructure for AI agents. Each agent gets its own real inbox; inbound mail is parsed to JSON with OTP codes, verification links and magic links extracted, plus long-poll endpoints that block until the code arrives, IMAP access, and 103 MCP tools.
 
 ## Related
 


### PR DESCRIPTION
Adding Lumbox under Platforms/API.

Lumbox gives an AI agent its own real email inbox and parses inbound mail to JSON, extracting OTP codes, verification links and magic links, with long-poll endpoints so the agent blocks until the code arrives instead of running a polling loop. It connects an agent to the real world through email, which is what this section covers.

It is a hosted API rather than an open-source repo, so the entry has no stars badge, matching the existing website-only entries in this section (BidClub, Crewship, Taskade Genesis).