### PR TITLE
Add berth to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ Exploring endless possibilities with open-source agent social simulation.
 - [Agent Coordinator](https://github.com/alanhoff/agent-coordinator) - Codex skill that records complex tasks as revisioned work graphs, rejects overlapping write scopes, reconciles uncertain work before retry, and reruns completion checks. ![GitHub Repo stars](https://img.shields.io/github/stars/alanhoff/agent-coordinator?style=social)
 - [sofagent](https://github.com/KongFangXun/sofagent) - Audit-first governance harness for AI coding agents: 24 rules enforced at commit time via git hooks, HMAC-chained audit log, snapshot rollback. MIT. ![GitHub Repo stars](https://img.shields.io/github/stars/KongFangXun/sofagent?style=social)
 - [Webcmd](https://github.com/agentrhq/webcmd) - Self-learning browser infrastructure for AI agents: learns a site's navigation once, then compiles it into deterministic per-site CLI commands. TypeScript, Apache-2.0. ![GitHub Repo stars](https://img.shields.io/github/stars/agentrhq/webcmd?style=social)
+- [berth](https://github.com/Mrjwj34/berth) - Daemonless local workspaces for parallel coding agents: one Git worktree per workspace, a private data directory, atomically reserved ports, and supervised processes. ![GitHub Repo stars](https://img.shields.io/github/stars/Mrjwj34/berth?style=social)
 
 ## Frameworks
 


### PR DESCRIPTION
## Summary
Adds berth to `### Tools`: a CLI that gives each task its own local workspace -- one Git worktree, a private data directory, reserved ports and supervised processes.

## Type of change
- [x] Add new resource entry

## Target section
- [x] Applications / Tools

## Quality checks (required)
- [x] I searched `README.md` and confirmed this is not a duplicate.
- [x] The submission is relevant to the AI agent ecosystem.
- [x] The description is neutral and evidence-based (not promotional).
- [x] I removed unverifiable claims (e.g., "best", "first") or provided clear evidence.
- [x] If this is open source, license information is clear.
- [x] The linked project/resource has usable documentation (README/docs).
- [x] If this project depends on a paid or closed hosted service, the OSS artifact still has clear standalone value and this PR does not function mainly as service promotion.

## Proposed entry line

```md
- [berth](https://github.com/Mrjwj34/berth) - Daemonless local workspaces for parallel coding agents: one Git worktree per workspace, a private data directory, atomically reserved ports, and supervised processes. ![GitHub Repo stars](https://img.shields.io/github/stars/Mrjwj34/berth?style=social)
```

https://github.com/Mrjwj34/berth