### PR TITLE
Add Oathra to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ Exploring endless possibilities with open-source agent social simulation.
 
 ### Tools
 
+- [Oathra](https://github.com/FORIFOR/oathra) - Apache-2.0 TypeScript runtime for AI agents that make phone calls (Twilio or SIP via LiveKit); every result field is anchored to the callee's words and completion is decided by deterministic rules, with a 10,000-run adversarial evaluation in the repo. Playable simulator needs no API key. ![GitHub Repo stars](https://img.shields.io/github/stars/FORIFOR/oathra?style=social)
 - [DSH Studio](https://github.com/Moresyl/dsh-studio) - Cross-platform desktop host for installing, running, health-checking, and supervising DeepSeek Harness locally. ![GitHub Repo stars](https://img.shields.io/github/stars/Moresyl/dsh-studio?style=social)
 - [Lians](https://github.com/Lians-ai/Lians) - Local-first memory layer for AI agents with MCP, Python, and TypeScript interfaces; SQLite-backed recall, user-controlled inspection/correction/deletion, and point-in-time memory receipts. ![GitHub Repo stars](https://img.shields.io/github/stars/Lians-ai/Lians?style=social)
 - [Perseus](https://github.com/tcconnally/perseus) - Live workspace context engine for AI agents. Renders AGENTS.md at session start. Plug-in for Claude Code, Codex, Hermes.


### PR DESCRIPTION
Adds Oathra under **Tools**.

- **License**: Apache-2.0, TypeScript.
- **Standalone OSS value**: the evidence-verification engine anchors outcome fields to callee utterances and applies deterministic completion rules; the repository includes a simulator, scripted callee characters, Arena UI, scenario DSL and adversarial evaluation.
- **Scope**: a phone-agent runtime with Twilio direct media streams or SIP through a LiveKit gateway, plus GPT-Live, OpenAI Realtime and STT+LLM+TTS voice-engine adapters.
- **Follow-up intake**: purpose and consent are declared in the contract; questions are limited to one declared field per turn and explicit answers retain utterance provenance; decline, hold, ambiguity and time pressure stop collection.
- **Current release**: [v0.1.16](https://github.com/FORIFOR/oathra/releases/tag/v0.1.16), with architecture documentation, English and Japanese scenarios and a setup guide.
- **Documentation**: [project site](https://forifor.github.io/oathra/en/) and [intake recording](https://forifor.github.io/oathra/en/#intake-video).
- The README was searched and the project is not duplicated in the list.

